### PR TITLE
fix tests for new version

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -184,7 +184,7 @@ func (b *Bridge) proxyMediaRTP(m1 media.RTPReader, m2 media.RTPWriter) (written 
 	for {
 		p := rtp.Packet{}
 		// In case of recording we need to unmarshal RTP packet
-		err := m1.ReadRTP(buf, &p)
+		_, err := m1.ReadRTP(buf, &p)
 		if err != nil {
 			return total, err
 		}

--- a/diago.go
+++ b/diago.go
@@ -542,7 +542,7 @@ func (dg *Diago) InviteBridge(ctx context.Context, recipient sip.Uri, bridge *Br
 	if fromHDR := inviteReq.From(); fromHDR != nil {
 		fromHDR.Params["tag"] = sip.GenerateTagN(16)
 		if fromHDR.Address.Host == "" { // IN case caller is set but not hostname
-			fromHDR.Address.Host = dg.client.Hostname()
+			fromHDR.Address.Host = dg.client.GetHostname()
 		}
 	}
 

--- a/diago_test.go
+++ b/diago_test.go
@@ -62,7 +62,7 @@ func TestDiagoInviteCallerID(t *testing.T) {
 		req := <-reqCh
 
 		assert.Equal(t, dg.ua.Name(), req.From().Address.User)
-		assert.Equal(t, dg.ua.Hostname(), req.From().Address.Host)
+		assert.Equal(t, dg.client.GetHostname(), req.From().Address.Host)
 		assert.NotEmpty(t, req.From().Params["tag"])
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/emiago/sipgo v0.24.2-0.20241009194434-f8762ab672dc
 	github.com/go-audio/riff v1.0.0
 	github.com/go-audio/wav v1.1.0
-	github.com/icholy/digest v0.1.22
 	github.com/pion/rtcp v1.2.14
 	github.com/pion/rtp v1.8.9
 	github.com/rs/zerolog v1.33.0
@@ -21,6 +20,7 @@ require (
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/icholy/digest v0.1.22 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/emiago/sipgo v0.24.1-0.20241002122238-e2d0c4c77196 h1:fi237GnKOwEWGr1SMb2wLUHPOU0ogrA57hf+2upX6II=
-github.com/emiago/sipgo v0.24.1-0.20241002122238-e2d0c4c77196/go.mod h1:UB0Ao5xk1b1TQisO29jmUDz0mXNINpHBR4YXsLbLXEs=
-github.com/emiago/sipgo v0.24.1 h1:RKy6NqVnvjgpLywo1sa4v+lwfEz5O5/0yk4Z8eek4XM=
-github.com/emiago/sipgo v0.24.1/go.mod h1:UB0Ao5xk1b1TQisO29jmUDz0mXNINpHBR4YXsLbLXEs=
 github.com/emiago/sipgo v0.24.2-0.20241009194434-f8762ab672dc h1:ghykSr4pZIrIJOC54aWkqag4FI1OaB7tSQ2pCTOWpIE=
 github.com/emiago/sipgo v0.24.2-0.20241009194434-f8762ab672dc/go.mod h1:UB0Ao5xk1b1TQisO29jmUDz0mXNINpHBR4YXsLbLXEs=
 github.com/go-audio/audio v1.0.0 h1:zS9vebldgbQqktK4H0lUqWrG8P0NxCJVqcj7ZpNnwd4=

--- a/main_benchmark_test.go
+++ b/main_benchmark_test.go
@@ -148,7 +148,7 @@ func BenchmarkIntegrationClientServer(t *testing.B) {
 						reader := dialog.mediaSession
 						for {
 							p := rtp.Packet{}
-							err := reader.ReadRTP(buf, &p)
+							_, err := reader.ReadRTP(buf, &p)
 							if err != nil {
 								return
 							}


### PR DESCRIPTION
Due new changes, I fixed some tests so lib can be used, otherwise error appears when running 

```
# github.com/emiago/diago
/go/pkg/mod/github.com/emiago/diago@v0.5.0/diago.go:545:37: dg.client.Hostname undefined (type *sipgo.Client has no field or method Hostname, but does have unexported field hostname)
```