### PR TITLE
Fix for usage of SIP URI

### DIFF
--- a/diago.go
+++ b/diago.go
@@ -739,7 +739,7 @@ func (dg *Diago) getTransport(transport string) (Transport, bool) {
 		return dg.transports[0], true
 	}
 	for _, t := range dg.transports {
-		if sip.NetworkToLower(transport) == t.Transport {
+		if sip.NetworkToLower(transport) == sip.NetworkToLower(t.Transport) {
 			return t, true
 		}
 	}
@@ -789,7 +789,7 @@ func (dg *Diago) Register(ctx context.Context, recipient sip.Uri, opts RegisterO
 // Register transaction creates register transaction object that can be used for Register Unregister requests
 func (dg *Diago) RegisterTransaction(ctx context.Context, recipient sip.Uri, opts RegisterOptions) (*RegisterTransaction, error) {
 	// Make our client reuse address
-	transport := recipient.Headers["transport"]
+	transport := recipient.UriParams["transport"]
 	if transport == "" {
 		transport = "udp"
 	}


### PR DESCRIPTION
Running into issues doing REGISTER because of transport supposedly not being found.
The issue is caused by diago.RegisterTransaction() checking recipient.Headers instead of UriParams to find the transport and also due to case sensitivity when comparing say "udp" with "UDP".

From what I have gathered in RFC:

* Transport should be in Headers instead of UriParams
* Transport should be case-insensitive, thus comparison should be between lower cased transport strings

This PR attempts to fix this.