### PR TITLE
fix: end a record with \n\r

### DIFF
--- a/media/sdp/sdp_test.go
+++ b/media/sdp/sdp_test.go
@@ -35,7 +35,8 @@ a=rtpmap:122 telephone-event/32000
 a=fmtp:122 0-16
 a=ssrc:1204560450 cname:4585300731f880ff
 a=rtcp:57798 IN IP4 192.168.100.11
-a=rtcp-mux`
+a=rtcp-mux
+`
 
 	// Fails due to b=TIAS:64000
 	sd := SessionDescription{}

--- a/media/sdp/utils.go
+++ b/media/sdp/utils.go
@@ -95,6 +95,6 @@ func GenerateForAudio(originIP net.IP, connectionIP net.IP, rtpPort int, mode Mo
 	// 	fmt.Sprintf("a=rtcp:%d IN IP4 %s", rtpPort+1, connectionIP),
 	// }
 
-	res := strings.Join(s, "\r\n")
+	res := strings.Join(s, "\r\n") + "\r\n"
 	return []byte(res)
 }


### PR DESCRIPTION
Text fields such as the session name and information are octet strings that may contain any octet with the exceptions of 0x00 (Nul), 0x0a (ASCII newline), and 0x0d (ASCII carriage return). The sequence CRLF (0x0d0a) is used to end a record, although parsers SHOULD be tolerant and also accept records terminated with a single newline character.