### PR TITLE
Add ExtraHeaders option to RegisterOptions

### DIFF
--- a/diago.go
+++ b/diago.go
@@ -730,6 +730,10 @@ type RegisterOptions struct {
 	RetryInterval time.Duration
 	AllowHeaders  []string
 
+	// extra headers to pass, will be added to REGISTER request
+	// for example: User-Agent: myuseragent/1.0
+	ExtraHeaders []sip.Header
+
 	// Useragent default will be used on what is provided as NewUA()
 	// UserAgent         string
 	// UserAgentHostname string

--- a/register_transaction.go
+++ b/register_transaction.go
@@ -50,6 +50,11 @@ func newRegisterTransaction(client *sipgo.Client, recipient sip.Uri, contact sip
 	if opts.ProxyHost != "" {
 		req.SetDestination(opts.ProxyHost)
 	}
+
+	for _, header := range opts.ExtraHeaders {
+		req.AppendHeader(header)
+	}
+
 	if expiry > 0 {
 		expires := sip.ExpiresHeader(expiry.Seconds())
 		req.AppendHeader(&expires)


### PR DESCRIPTION
This will allow easily setting custom params while using `.Register` method, such as a non-standard `User-Agent`.