### PR TITLE
feat: avoid selecting 101 telephone-event by default

### DIFF
--- a/media/codec.go
+++ b/media/codec.go
@@ -48,6 +48,14 @@ func (c *Codec) SamplesPCM(bitSize int) int {
 }
 
 func CodecFromSession(s *MediaSession) Codec {
+	for _, codec := range s.Codecs {
+		if codec.Name == "telephone-event" {
+			continue
+		}
+
+		return codec
+	}
+
 	return s.Codecs[0]
 }
 


### PR DESCRIPTION
For some reasons, [Zoiper](https://www.zoiper.com/en/voip-softphone/download/current) sends `m: audio <PORT> RTP/AVP 9 101 0 8 3` and that means that here telephone event has more priority than PCMU, PCMA.

What IF could be possible to avoid 101 and pick PCMU?