### PR TITLE
Allow to specify 'tag' parameter in INVITE requests

### DIFF
--- a/dialog_client_session.go
+++ b/dialog_client_session.go
@@ -213,7 +213,8 @@ func (d *DialogClientSession) Invite(ctx context.Context, opts InviteClientOptio
 	inviteReq.SetBody(sess.LocalSDP())
 
 	// We allow changing full from header, but we need to make sure it is correctly set
-	if fromHDR := inviteReq.From(); fromHDR != nil {
+	// If users specify 'tag' parameter it is assumed that they know what they do
+	if fromHDR := inviteReq.From(); fromHDR != nil && !fromHDR.Params.Has("tag") {
 		fromHDR.Params["tag"] = sip.GenerateTagN(16)
 	}
 


### PR DESCRIPTION
Allow users to specify `tag` parameter in `INVITE` requests.

The old behavior will work if `tag` is not specified.

If specified, it is assumed that users understand what they do and we don't need to rewrite the `tag`