### PR TITLE
Add `OnRegisterStateChange` callback for SIP registration lifecycle

### DIFF
--- a/diago.go
+++ b/diago.go
@@ -793,13 +793,13 @@ func (dg *Diago) Register(ctx context.Context, recipient sip.Uri, opts RegisterO
 				}
 			}
 		}
-
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
 
 		t.expiry = retryAfter
 	}
+	return nil
 }
 
 // Register transaction creates register transaction object that can be used for Register Unregister requests


### PR DESCRIPTION
This change introduces a new optional callback: OnRegisterStateChange.

The callback allows callers to observe SIP registration state transitions
during the Register transaction lifecycle.

What’s included:
- New OnRegisterStateChange callback exposed via RegisterOptions
- Callback is invoked with `true` when registration succeeds
- Callback is invoked with `false` when registration fails
- No behavior change for existing users unless the callback is provided

This makes it easier to track registration status, react to failures,
and integrate external state handling without polling or custom hacks.