### PR TITLE
prefer local codec priority order instead of remote codec priority order

### DIFF
--- a/media/media_session.go
+++ b/media/media_session.go
@@ -670,8 +670,8 @@ func (s *MediaSession) updateRemoteCodecs(codecs []Codec) int {
 
 	DefaultLogger().Debug("Remote Codecs Update", "local", s.Codecs, "remote", codecs)
 	filter := codecs[:0] // reuse buffer
-	for _, rc := range codecs {
-		for _, c := range s.Codecs {
+	for _, c := range s.Codecs {
+		for _, rc := range codecs {
 			if c == rc {
 				filter = append(filter, c)
 				break


### PR DESCRIPTION
I noticed in my logs that a remote peer supported 16kHz sample rate streams

```
DBG Remote Codecs Update local="[
{Name:opus PayloadType:96 SampleRate:48000 SampleDur:20ms NumChannels:2} 
{Name:PCMA PayloadType:120 SampleRate:16000 SampleDur:20ms NumChannels:1} 
{Name:PCMU PayloadType:121 SampleRate:16000 SampleDur:20ms NumChannels:1} 
{Name:PCMA PayloadType:8 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:PCMU PayloadType:0 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:telephone-event PayloadType:101 SampleRate:8000 SampleDur:20ms NumChannels:1}
]" 
remote="[{
Name:PCMA PayloadType:8 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:PCMU PayloadType:0 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:G726-32 PayloadType:2 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:G726-32 PayloadType:102 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:G726-40 PayloadType:100 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:G726-24 PayloadType:99 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:telephone-event PayloadType:101 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:iLBC PayloadType:97 SampleRate:8000 SampleDur:20ms NumChannels:1} 
{Name:PCMA PayloadType:120 SampleRate:16000 SampleDur:20ms NumChannels:1} 
{Name:PCMU PayloadType:121 SampleRate:16000 SampleDur:20ms NumChannels:1}
]"
```

but even though I put 16k PCMA before 8k PCMA in my local codec list, diago decided to go with

```
DBG call > audio bitdepth=16 channels=1 codec=PCMA samplerate=8000
```

This small change fixes that.