### PR TITLE
fix(media): skip SRTP encryption when remote peer has no crypto

### DIFF
--- a/media/media_session.go
+++ b/media/media_session.go
@@ -125,7 +125,6 @@ type MediaSession struct {
 	localCtxSRTP  *srtp.Context
 	remoteCtxSRTP *srtp.Context
 	srtpRemoteTag int
-	hasRemoteSDP  bool
 
 	// RTP NAT enables handling RTP behind NAT. Checkout also RTPSourceLock
 	RTPNAT          int // 0 - disabled, 1 - Learn source change (RTP Symetric)
@@ -322,7 +321,7 @@ func (s *MediaSession) LocalSDP() []byte {
 	if s.SecureRTP == 1 {
 		// RFC 4568/8643: only include crypto when offering (no remote SDP yet)
 		// or when the peer actually offered SRTP
-		if !s.hasRemoteSDP || s.remoteCtxSRTP != nil {
+		if s.Raddr.IP == nil || s.remoteCtxSRTP != nil {
 			err := func() error {
 				// TODO detect algorithm
 				profile := srtp.ProtectionProfile(s.SRTPAlg)
@@ -417,8 +416,6 @@ func (s *MediaSession) LocalSDP() []byte {
 // NOTE: It must called ONCE or single thread while negotiation happening.
 // For multi negotiation Fork Must be called before
 func (s *MediaSession) RemoteSDP(sdpReceived []byte) error {
-	s.hasRemoteSDP = true
-
 	sd := sdp.SessionDescription{}
 	if err := sdp.Unmarshal(sdpReceived, &sd); err != nil {
 		return fmt.Errorf("fail to parse received SDP: %w", err)


### PR DESCRIPTION
Fixes #129

When SecureRTP=1 (SDES), LocalSDP() unconditionally created an SRTP context causing encrypted outbound RTP toward peers expecting plaintext.

- Add hasRemoteSDP flag so answerer only includes crypto when the offerer actually offered SRTP
- Clear localCtxSRTP in offerer path when remote answer has no crypto

Also added a small unrelated fix in the same code:
- Fix TrimLeft→TrimPrefix for crypto tag parsing