### PR TITLE
Accept NOTIFY with message/sipfrag Content-Type without version.

### DIFF
--- a/dialog_session.go
+++ b/dialog_session.go
@@ -69,7 +69,7 @@ func dialogHandleReferNotify(d DialogSession, req *sip.Request, tx sip.ServerTra
 	// TODO how to know this is refer
 	contentType := req.ContentType().Value()
 	// For now very basic check
-	if !strings.HasPrefix(contentType, "message/sipfrag;version=2.0") {
+	if !strings.HasPrefix(contentType, "message/sipfrag") {
 		tx.Respond(sip.NewResponseFromRequest(req, sip.StatusBadRequest, "Bad Request", nil))
 		return
 	}


### PR DESCRIPTION
[RFC 3420 Section 5](https://www.rfc-editor.org/rfc/rfc3420#section-5) defines the version parameter as optional for message/sipfrag, defaulting to "2.0" when absent. The strict prefix check on "message/sipfrag;version=2.0" rejected valid REFER NOTIFY messages from PBXes that omit the optional parameter, preventing the OnNotify callback from ever firing. It would erroneously return '400 Bad Request' instead.

Specifically, we observed this with 3CX. 

This change relaxes the check to match on "message/sipfrag" prefix only. I don't directly expect negative effects: 
- existing code with the version parameter keep working as is
- code without the version suffix will now return correct answer as well

Potential edge case is if existing code relies on diago returning `400 bad request` during REFER.