### PR TITLE
fix(rtp): reset PaddingSize when Padding bit is unset (closes #140)

### DIFF
--- a/media/rtp_parse.go
+++ b/media/rtp_parse.go
@@ -43,6 +43,11 @@ func rtpUnmarshalPayload(n int, buf []byte, p *rtp.Packet) error {
 	if p.Header.Padding {
 		p.PaddingSize = buf[end-1]
 		end -= int(p.PaddingSize)
+	} else {
+		// Reset to 0 so a stale value from a previous packet (this *rtp.Packet
+		// is reused across reads) does not get subtracted in the downstream
+		// payloadSize calculation, which would truncate the payload. See #140.
+		p.PaddingSize = 0
 	}
 	if end < n {
 		return io.ErrShortBuffer

--- a/media/rtp_parse_test.go
+++ b/media/rtp_parse_test.go
@@ -10,7 +10,53 @@ import (
 	"github.com/emiago/sipgo/fakes"
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
 )
+
+// TestRTPUnmarshalResetsPaddingSize is a regression test for #140.
+//
+// `rtpUnmarshalPayload` reuses the *rtp.Packet across reads. When a
+// packet with Padding=true was followed by a packet with Padding=false,
+// the second packet's PaddingSize was left stale at the first packet's
+// value, causing the downstream payload-size calculation in
+// rtp_packet_reader.go (and rtp_session.go) to truncate the payload.
+func TestRTPUnmarshalResetsPaddingSize(t *testing.T) {
+	const payloadLen = 160
+	payload := make([]byte, payloadLen)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	// First packet: Padding=true. Marshal a packet whose padding is
+	// actually present in the wire bytes.
+	paddedPkt := rtp.Packet{
+		Header:  rtp.Header{Version: 2, Padding: true, PayloadType: 8, SequenceNumber: 1, Timestamp: 100, SSRC: 0xDEADBEEF, PaddingSize: 4},
+		Payload: payload,
+	}
+	paddedBuf, err := paddedPkt.Marshal()
+	require.NoError(t, err)
+
+	// Second packet: Padding=false, same SSRC, no padding in wire bytes.
+	cleanPkt := rtp.Packet{
+		Header:  rtp.Header{Version: 2, PayloadType: 8, SequenceNumber: 2, Timestamp: 260, SSRC: 0xDEADBEEF},
+		Payload: payload,
+	}
+	cleanBuf, err := cleanPkt.Marshal()
+	require.NoError(t, err)
+
+	// Reuse the same *rtp.Packet across both reads, exactly as
+	// rtp_packet_reader.go does.
+	pkt := &rtp.Packet{}
+
+	require.NoError(t, RTPUnmarshal(paddedBuf, pkt))
+	require.Equal(t, byte(4), pkt.PaddingSize, "first packet should report its padding size")
+	require.Len(t, pkt.Payload, payloadLen, "first packet payload should match input length")
+
+	require.NoError(t, RTPUnmarshal(cleanBuf, pkt))
+	require.Equal(t, byte(0), pkt.PaddingSize, "PaddingSize must reset when Padding bit is unset (#140)")
+	require.Len(t, pkt.Payload, payloadLen, "second packet's payload must not be truncated by stale PaddingSize")
+	require.Equal(t, payload, pkt.Payload, "second packet payload bytes must match input verbatim")
+}
 
 func BenchmarkRTCPUnmarshal(b *testing.B) {
 	reader, writer := io.Pipe()


### PR DESCRIPTION
### Summary

`rtpUnmarshalPayload` reuses the same `*rtp.Packet` across reads. When a packet with `Padding=true` is followed by one with `Padding=false`, the second packet's `PaddingSize` field is left stale at the first packet's value. The downstream payload-size calculation (`rtp_packet_reader.go:153`, `rtp_session.go:265`) subtracts `pkt.PaddingSize` unconditionally, so the stale value truncates the second packet's payload.

Reported and root-caused by @brandon-hc in #140.

### Fix

Reset `p.PaddingSize = 0` in the else branch of `rtpUnmarshalPayload`, matching pion/rtp's own `Unmarshal` behavior at [`packet.go:240-243`](https://github.com/pion/rtp/blob/v1.8.18/packet.go#L240-L243).

```diff
 	end := len(buf)
 	if p.Header.Padding {
 		p.PaddingSize = buf[end-1]
 		end -= int(p.PaddingSize)
+	} else {
+		p.PaddingSize = 0
 	}
```

The downstream consumers at `rtp_packet_reader.go:153` and `rtp_session.go:265` are unchanged — the fix is at the unmarshal layer where the field gets populated.

### Regression test

`TestRTPUnmarshalResetsPaddingSize` exercises the exact reuse scenario: marshal a padded packet, unmarshal into `pkt`, then marshal an unpadded packet and unmarshal into the same `pkt`. Asserts `pkt.PaddingSize == 0` and the full payload survives.

### Verification

| State | Platform | Result |
|---|---|---|
| Pre-fix | Windows + Go 1.26 | `FAIL: expected 0x0, actual 0x4` at `rtp_parse_test.go:56` — confirms the test exercises the bug |
| Post-fix | Windows + Go 1.26 | `PASS` (regression test + full `go test ./media/` suite, 1.7s) |
| Post-fix | Linux (golang:1.26 container) | `PASS` |

### Out of scope

- The pion `pkt.PaddingSize` field is now deprecated in favor of `pkt.Header.PaddingSize`. Diago still uses the legacy field; migrating is a larger structural change and a separate concern.
- Video support / refactoring discussed in the issue thread is orthogonal — this fix is correctness for any RTP usage, not video-specific.