### PR TITLE
fix: data race on shared ctx in serve when multiple transports are configured

### DIFF
--- a/diago.go
+++ b/diago.go
@@ -490,7 +490,7 @@ func (dg *Diago) serve(ctx context.Context, f ServeDialogFunc, readyCh func()) e
 
 		go func(i int, tran Transport) {
 			// Update transport
-			ctx = context.WithValue(ctx, sipgo.ListenReadyCtxKey, sipgo.ListenReadyFuncCtxValue(func(network, addr string) {
+			ctx := context.WithValue(ctx, sipgo.ListenReadyCtxKey, sipgo.ListenReadyFuncCtxValue(func(network, addr string) {
 				// This now fixes port for empheral binding
 				// Alternative to use is tp.GetListenPort but it squashes networks
 				_, port, _ := sip.ParseAddr(addr)


### PR DESCRIPTION
In `(*Diago).serve`, the per-transport goroutine reassigns the outer captured `ctx` giving multiple goroutines access to the same ctx slot:

```go
// diago.go:491-513
for i, tran := range dg.transports {
  go func(i int, tran Transport) {
    ctx = context.WithValue(ctx, sipgo.ListenReadyCtxKey, ...)  // bug here: `=`, not `:=`
       // code omitted
      errCh <- server.ListenAndServe(ctx, tran.network, hostport)
    }(i, tran)
  }
```

When Diago is configured with more than one transport (e.g., UDP + TCP), every goroutine then writes and reads from the same `ctx` variable slot. This triggered the race detector in our test suite. 

I think the assignment this way was unintentional. This PR addresses it by shadowing the `ctx` variable within the goroutine. Behavior is unchanged. 

note: It may be more explicit to use a different name for the variable rather than shadowing, but I think in this context (spawning of a new go routine) it seemed acceptable.