### PR TITLE
fix: reset PaddingSize to 0 when reused rtp.Packet has no padding flag

### DIFF
--- a/media/rtp_parse.go
+++ b/media/rtp_parse.go
@@ -33,6 +33,11 @@ func rtpUnmarshalPayload(n int, buf []byte, p *rtp.Packet) error {
 	if p.Header.Padding {
 		p.PaddingSize = buf[end-1]
 		end -= int(p.PaddingSize)
+	} else {
+		// Clear PaddingSize when the packet reuses a *rtp.Packet that previously
+		// had padding. Without this reset, the stale PaddingSize truncates the
+		// payload of every subsequent non-padded packet in the same session.
+		p.PaddingSize = 0
 	}
 	if end < n {
 		return io.ErrShortBuffer

--- a/media/rtp_parse_test.go
+++ b/media/rtp_parse_test.go
@@ -12,6 +12,63 @@ import (
 	"github.com/pion/rtp"
 )
 
+// TestRTPUnmarshalPayload_PaddingSizeReset verifies that when a reused *rtp.Packet
+// previously had padding, rtpUnmarshalPayload resets PaddingSize to 0 for the next
+// packet that does not carry the Padding flag. Without the fix, PaddingSize persists
+// and causes the payload of subsequent non-padded packets to be truncated.
+func TestRTPUnmarshalPayload_PaddingSizeReset(t *testing.T) {
+	payload := []byte("hello world RTP payload data")
+
+	// Build a padded packet: append 4 bytes of padding (last byte = padding length).
+	paddingLen := byte(4)
+	paddedPayload := make([]byte, len(payload)+int(paddingLen))
+	copy(paddedPayload, payload)
+	paddedPayload[len(paddedPayload)-1] = paddingLen
+
+	paddedPkt := rtp.Packet{}
+	paddedPkt.Header.Padding = true
+	marshaledPadded, err := rtp.Packet{
+		Header:  rtp.Header{Padding: true, Version: 2},
+		Payload: paddedPayload,
+	}.Marshal()
+	if err != nil {
+		t.Fatal("marshal padded packet:", err)
+	}
+
+	// Parse the padded packet — this sets PaddingSize on reusedPkt.
+	reusedPkt := &rtp.Packet{Payload: make([]byte, 1500)}
+	if err := reusedPkt.Unmarshal(marshaledPadded); err != nil {
+		t.Fatal("unmarshal padded:", err)
+	}
+	if reusedPkt.PaddingSize == 0 {
+		t.Skip("pion/rtp version does not expose PaddingSize — skipping")
+	}
+
+	// Now build a plain packet with no padding carrying the same payload.
+	plainPkt := rtp.Packet{
+		Header:  rtp.Header{Version: 2},
+		Payload: payload,
+	}
+	marshaledPlain, err := plainPkt.Marshal()
+	if err != nil {
+		t.Fatal("marshal plain packet:", err)
+	}
+
+	// Unmarshal the plain packet into the same reused struct.
+	// Before the fix, PaddingSize from the padded parse still lingers and
+	// truncates the payload by paddingLen bytes.
+	if err := reusedPkt.Unmarshal(marshaledPlain); err != nil {
+		t.Fatal("unmarshal plain:", err)
+	}
+
+	if reusedPkt.PaddingSize != 0 {
+		t.Errorf("PaddingSize not reset: got %d, want 0", reusedPkt.PaddingSize)
+	}
+	if string(reusedPkt.Payload) != string(payload) {
+		t.Errorf("payload truncated: got %q, want %q", reusedPkt.Payload, payload)
+	}
+}
+
 func BenchmarkRTCPUnmarshal(b *testing.B) {
 	reader, writer := io.Pipe()
 	go func() {


### PR DESCRIPTION
## Problem

Closes #140.

When `*rtp.Packet` is reused across reads (the common pattern for zero-allocation parsing), `PaddingSize` set by a previous padded packet persists into the next `rtpUnmarshalPayload` call. If the next packet does not set `Header.Padding`, the existing code skips the reset, so `end` is calculated as `len(buf) - PaddingSize` using the stale value — silently truncating the payload by that many bytes.

**Reproduction sequence (from the issue):**
1. `rtpUnmarshalPayload` parses a padded packet → sets `PaddingSize = 4`
2. Payload correctly computed as `len(buf) - 4`
3. `rtpUnmarshalPayload` parses the next non-padded packet using same `*rtp.Packet`
4. `Header.Padding` is `false` → skip branch → `PaddingSize` stays `4`
5. Payload silently truncated by 4 bytes

## Fix

Add an `else` branch in `rtpUnmarshalPayload` that sets `p.PaddingSize = 0` when `Header.Padding` is false.

```go
if p.Header.Padding {
    p.PaddingSize = buf[end-1]
    end -= int(p.PaddingSize)
} else {
    p.PaddingSize = 0  // ← reset stale value from previous padded packet
}
```

## Test

`TestRTPUnmarshalPayload_PaddingSizeReset` — parses a padded packet into a reused struct, then parses a non-padded packet into the same struct and asserts `PaddingSize == 0` and payload is not truncated.