### PR TITLE
fix: handle REFER rejection and NOTIFY timeout to prevent dialog leakage

### DIFF
--- a/dialog_client_session.go
+++ b/dialog_client_session.go
@@ -566,9 +566,11 @@ func (d *DialogClientSession) reInviteKeepAlive(ctx context.Context) error {
 	return nil
 }
 
-// Refer tries todo refer (blind transfer) on call. For more control use ReferOptions
+// Refer tries todo refer (blind transfer) on call. For more control use ReferOptions.
 //
-// NOTE: It is expected that after calling this you are hanguping call to send BYE
+// On REFER rejection (non-202), BYE is sent automatically to prevent dialog leakage.
+// On successful REFER, the default NOTIFY handler sends BYE when status >= 200 arrives.
+// Use ReferOptions with ReferTimeout to guard against missing NOTIFY.
 func (d *DialogClientSession) Refer(ctx context.Context, referTo sip.Uri, headers ...sip.Header) error {
 	// cont := d.InviteRequest.Contact()
 	// return dialogRefer(ctx, d, cont.Address, referTo, headers...)
@@ -580,8 +582,13 @@ func (d *DialogClientSession) Refer(ctx context.Context, referTo sip.Uri, header
 type ReferClientOptions struct {
 	Headers []sip.Header
 	// OnNotify sends notify status code.
-	// If implemented you need to react on different status code.
+	// If implemented you need to react on different status code and manage dialog lifecycle.
 	OnNotify func(statusCode int)
+	// ReferTimeout is the max duration to wait for a final NOTIFY (status >= 200) after
+	// REFER is accepted. If set and no final NOTIFY arrives within this time, BYE is sent.
+	// Only applies when OnNotify is nil (auto-BYE mode). Zero means no timeout (caller
+	// relies on the default NOTIFY-triggered hangup in dialogHandleReferNotify).
+	ReferTimeout time.Duration
 }
 
 func (d *DialogClientSession) ReferOptions(ctx context.Context, referTo sip.Uri, opts ReferClientOptions) error {
@@ -591,7 +598,36 @@ func (d *DialogClientSession) ReferOptions(ctx context.Context, referTo sip.Uri,
 		d.onReferNotify = opts.OnNotify
 	}
 	d.mu.Unlock()
-	return dialogRefer(ctx, d, cont.Address, referTo, d.InviteResponse.Contact().Address, opts.Headers...)
+
+	err := dialogRefer(ctx, d, cont.Address, referTo, d.InviteResponse.Contact().Address, opts.Headers...)
+	if err != nil {
+		// REFER was rejected (405/488/5xx/6xx). If caller is not handling notifications
+		// themselves, send BYE to prevent dialog leakage.
+		if opts.OnNotify == nil {
+			return errors.Join(err, d.Hangup(ctx))
+		}
+		return err
+	}
+
+	// REFER accepted (202). If caller set a ReferTimeout and is not handling
+	// notifications themselves, start a timer. If no final NOTIFY (>= 200)
+	// arrives within the timeout, send BYE to prevent dialog leakage.
+	if opts.OnNotify == nil && opts.ReferTimeout > 0 {
+		go func() {
+			timer := time.NewTimer(opts.ReferTimeout)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+				// No final NOTIFY received within timeout — send BYE
+				d.Hangup(context.Background())
+			case <-d.Context().Done():
+				// Dialog ended normally (BYE from remote, or NOTIFY triggered hangup)
+				return
+			}
+		}()
+	}
+
+	return nil
 }
 
 func (d *DialogClientSession) handleReferNotify(req *sip.Request, tx sip.ServerTransaction) {

--- a/dialog_server_session.go
+++ b/dialog_server_session.go
@@ -476,9 +476,11 @@ func (d *DialogServerSession) remoteContactUnsafe() *sip.ContactHeader {
 	return d.InviteRequest.Contact()
 }
 
-// Refer tries todo refer (blind transfer) on call. For more control use ReferOptions
+// Refer tries todo refer (blind transfer) on call. For more control use ReferOptions.
 //
-// NOTE: It is expected that after calling this you are hanguping call to send BYE
+// On REFER rejection (non-202), BYE is sent automatically to prevent dialog leakage.
+// On successful REFER, the default NOTIFY handler sends BYE when status >= 200 arrives.
+// Use ReferOptions with ReferTimeout to guard against missing NOTIFY.
 func (d *DialogServerSession) Refer(ctx context.Context, referTo sip.Uri, headers ...sip.Header) error {
 	// cont := d.InviteRequest.Contact()
 	// return dialogRefer(ctx, d, cont.Address, referTo, headers...)
@@ -488,8 +490,15 @@ func (d *DialogServerSession) Refer(ctx context.Context, referTo sip.Uri, header
 }
 
 type ReferServerOptions struct {
-	Headers  []sip.Header
+	Headers []sip.Header
+	// OnNotify sends notify status code.
+	// If implemented you need to react on different status code and manage dialog lifecycle.
 	OnNotify func(statusCode int)
+	// ReferTimeout is the max duration to wait for a final NOTIFY (status >= 200) after
+	// REFER is accepted. If set and no final NOTIFY arrives within this time, BYE is sent.
+	// Only applies when OnNotify is nil (auto-BYE mode). Zero means no timeout (caller
+	// relies on the default NOTIFY-triggered hangup in dialogHandleReferNotify).
+	ReferTimeout time.Duration
 }
 
 func (d *DialogServerSession) ReferOptions(ctx context.Context, referTo sip.Uri, opts ReferServerOptions) error {
@@ -499,7 +508,36 @@ func (d *DialogServerSession) ReferOptions(ctx context.Context, referTo sip.Uri,
 		d.onReferNotify = opts.OnNotify
 	}
 	d.mu.Unlock()
-	return dialogRefer(ctx, d, cont.Address, referTo, d.InviteResponse.Contact().Address, opts.Headers...)
+
+	err := dialogRefer(ctx, d, cont.Address, referTo, d.InviteResponse.Contact().Address, opts.Headers...)
+	if err != nil {
+		// REFER was rejected (405/488/5xx/6xx). If caller is not handling notifications
+		// themselves, send BYE to prevent dialog leakage.
+		if opts.OnNotify == nil {
+			return errors.Join(err, d.Hangup(ctx))
+		}
+		return err
+	}
+
+	// REFER accepted (202). If caller set a ReferTimeout and is not handling
+	// notifications themselves, start a timer. If no final NOTIFY (>= 200)
+	// arrives within the timeout, send BYE to prevent dialog leakage.
+	if opts.OnNotify == nil && opts.ReferTimeout > 0 {
+		go func() {
+			timer := time.NewTimer(opts.ReferTimeout)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+				// No final NOTIFY received within timeout — send BYE
+				d.Hangup(context.Background())
+			case <-d.Context().Done():
+				// Dialog ended normally (BYE from remote, or NOTIFY triggered hangup)
+				return
+			}
+		}()
+	}
+
+	return nil
 }
 
 func (d *DialogServerSession) handleReferNotify(req *sip.Request, tx sip.ServerTransaction) {

--- a/dialog_server_session_test.go
+++ b/dialog_server_session_test.go
@@ -332,6 +332,224 @@ func TestIntegrationDialogServerRefer(t *testing.T) {
 	})
 }
 
+func TestIntegrationDialogServerReferRejection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Dialer WITHOUT OnRefer handler — will reject REFER with 406
+	var dialer *Diago
+	{
+		ua, _ := sipgo.NewUA(sipgo.WithUserAgent("dialer-norefer"))
+		defer ua.Close()
+
+		dg := NewDiago(ua, WithTransport(
+			Transport{
+				Transport: "udp",
+				BindHost:  "127.0.0.1",
+				BindPort:  15081,
+				ID:        "udp",
+			},
+		))
+
+		err := dg.ServeBackground(ctx, nil)
+		require.NoError(t, err)
+		dialer = dg
+	}
+
+	dialCall := func() {
+		dialog, err := dialer.NewDialog(sip.Uri{User: "dialer", Host: "127.0.0.1", Port: 15080}, NewDialogOptions{})
+		require.NoError(t, err)
+
+		go func() {
+			// No OnRefer set — REFER will be rejected by dialer
+			err := dialog.Invite(ctx, InviteClientOptions{})
+			require.NoError(t, err)
+
+			dialog.Ack(ctx)
+			<-dialog.Context().Done()
+			t.Log("Dialog done")
+		}()
+	}
+
+	ua, _ := sipgo.NewUA()
+	defer ua.Close()
+
+	dg := NewDiago(ua, WithTransport(
+		Transport{
+			Transport: "udp",
+			BindHost:  "127.0.0.1",
+			BindPort:  15080,
+		},
+	))
+
+	waitDialog := make(chan *DialogServerSession)
+	err := dg.ServeBackground(ctx, func(d *DialogServerSession) {
+		t.Log("Call received")
+		waitDialog <- d
+		<-d.Context().Done()
+	})
+	require.NoError(t, err)
+
+	t.Run("ReferRejected405_AutoBYE", func(t *testing.T) {
+		dialCall()
+		d := <-waitDialog
+
+		err = d.Answer()
+		require.NoError(t, err)
+
+		// Send REFER without OnNotify — auto-BYE mode
+		// Dialer has no OnRefer handler, so it responds 406 Not Acceptable
+		err = d.ReferOptions(d.Context(), sip.Uri{Host: "127.0.0.1", Port: 15082}, ReferServerOptions{})
+		// REFER should return error (non-202 response)
+		assert.Error(t, err)
+
+		// Dialog should be terminated (BYE sent automatically)
+		select {
+		case <-d.Context().Done():
+			// Good — dialog ended due to auto-BYE
+		case <-time.After(5 * time.Second):
+			t.Fatal("Dialog did not terminate after REFER rejection — BYE was not sent")
+		}
+	})
+
+	t.Run("ReferRejected_WithOnNotify_NoBYE", func(t *testing.T) {
+		dialCall()
+		d := <-waitDialog
+
+		err = d.Answer()
+		require.NoError(t, err)
+
+		// Send REFER WITH OnNotify — caller manages lifecycle
+		err = d.ReferOptions(d.Context(), sip.Uri{Host: "127.0.0.1", Port: 15082}, ReferServerOptions{
+			OnNotify: func(statusCode int) {
+				// Caller handles it
+			},
+		})
+		// REFER should return error (non-202 response)
+		assert.Error(t, err)
+
+		// Dialog should NOT be auto-terminated — caller owns lifecycle
+		select {
+		case <-d.Context().Done():
+			t.Fatal("Dialog was terminated but OnNotify was set — should not auto-BYE")
+		case <-time.After(1 * time.Second):
+			// Good — dialog still alive, caller has control
+		}
+
+		// Clean up
+		d.Hangup(ctx)
+	})
+}
+
+func TestIntegrationDialogServerReferTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Dialer with OnRefer that accepts but never sends final NOTIFY (simulates lost NOTIFY)
+	var dialer *Diago
+	{
+		ua, _ := sipgo.NewUA(sipgo.WithUserAgent("dialer-timeout"))
+		defer ua.Close()
+
+		dg := NewDiago(ua, WithTransport(
+			Transport{
+				Transport: "udp",
+				BindHost:  "127.0.0.1",
+				BindPort:  15091,
+				ID:        "udp",
+			},
+		))
+
+		err := dg.ServeBackground(ctx, nil)
+		require.NoError(t, err)
+		dialer = dg
+	}
+
+	// UAS that accepts the REFER'd INVITE but never finishes (simulates hang)
+	{
+		ua, _ := sipgo.NewUA()
+		defer ua.Close()
+
+		dg := NewDiago(ua, WithTransport(
+			Transport{
+				Transport: "udp",
+				BindHost:  "127.0.0.1",
+				BindPort:  15092,
+			},
+		))
+
+		err := dg.ServeBackground(ctx, func(d *DialogServerSession) {
+			// Accept call but just hang — never complete to trigger final NOTIFY
+			d.Ringing()
+			<-d.Context().Done()
+		})
+		require.NoError(t, err)
+	}
+
+	ua, _ := sipgo.NewUA()
+	defer ua.Close()
+
+	dg := NewDiago(ua, WithTransport(
+		Transport{
+			Transport: "udp",
+			BindHost:  "127.0.0.1",
+			BindPort:  15090,
+		},
+	))
+
+	waitDialog := make(chan *DialogServerSession)
+	err := dg.ServeBackground(ctx, func(d *DialogServerSession) {
+		t.Log("Call received")
+		waitDialog <- d
+		<-d.Context().Done()
+	})
+	require.NoError(t, err)
+
+	t.Run("NotifyTimeout_AutoBYE", func(t *testing.T) {
+		dialCall := func() {
+			dialog, err := dialer.NewDialog(sip.Uri{User: "dialer", Host: "127.0.0.1", Port: 15090}, NewDialogOptions{})
+			require.NoError(t, err)
+
+			go func() {
+				err := dialog.Invite(ctx, InviteClientOptions{
+					OnRefer: func(referDialog *DialogClientSession) error {
+						// Accept REFER but send INVITE to a target that never answers
+						if err := referDialog.Invite(ctx, InviteClientOptions{}); err != nil {
+							return err
+						}
+						// Never send final NOTIFY >= 200 (simulates lost/stuck scenario)
+						<-referDialog.Context().Done()
+						return nil
+					},
+				})
+				require.NoError(t, err)
+				dialog.Ack(ctx)
+				<-dialog.Context().Done()
+			}()
+		}
+
+		dialCall()
+		d := <-waitDialog
+
+		err = d.Answer()
+		require.NoError(t, err)
+
+		// Send REFER with short timeout — no OnNotify (auto-BYE mode)
+		err = d.ReferOptions(d.Context(), sip.Uri{Host: "127.0.0.1", Port: 15092}, ReferServerOptions{
+			ReferTimeout: 3 * time.Second, // Short timeout for test
+		})
+		require.NoError(t, err)
+
+		// Dialog should terminate within timeout + margin
+		select {
+		case <-d.Context().Done():
+			// Good — dialog ended due to timeout BYE
+		case <-time.After(10 * time.Second):
+			t.Fatal("Dialog did not terminate after NOTIFY timeout — BYE was not sent")
+		}
+	})
+}
+
 func TestIntegrationDialogServerPlayback(t *testing.T) {
 	rtpBuf := newRTPWriterBuffer()
 	dialog := &DialogServerSession{


### PR DESCRIPTION
Fixes #147

## Changes

**Bug 1 — REFER rejection not triggering BYE:**
- In `ReferOptions()` (both server and client sessions), when REFER is rejected (non-202 response) and `OnNotify` is nil, automatically send BYE via `errors.Join(err, d.Hangup(ctx))` to prevent dialog leakage.

**Bug 2 — Missing NOTIFY >= 200 not triggering BYE:**
- Add `ReferTimeout time.Duration` field to `ReferServerOptions` and `ReferClientOptions`.
- When `ReferTimeout > 0` and `OnNotify` is nil, a goroutine starts a timer after REFER acceptance. If no final NOTIFY arrives (which would trigger `dialogHandleReferNotify` → BYE → context cancellation) within the timeout, BYE is sent automatically.
- Timer respects dialog context — exits cleanly if dialog ends normally before timeout.

**No breaking changes:**
- `OnNotify` set → caller manages lifecycle (no auto-BYE, no timeout). Existing behavior preserved.
- `ReferTimeout` zero → no timeout (existing behavior).
- `Refer()` convenience method now delegates to `ReferOptions()` for consistent behavior.

## Testing

Added integration tests in `dialog_server_session_test.go`:
- `TestIntegrationDialogServerReferRejection` — verifies auto-BYE on 405 rejection, and no BYE when OnNotify is set
- `TestIntegrationDialogServerReferTimeout` — verifies BYE fires after timeout when no final NOTIFY arrives