### PR TITLE
media: release rtcpMU when WriteRTP rejects an unknown payload type

### DIFF
--- a/media/rtp_session.go
+++ b/media/rtp_session.go
@@ -323,7 +323,11 @@ func (s *RTPSession) WriteRTP(pkt *rtp.Packet) error {
 		return err
 	}
 
+	// Unlock on defer: the codec lookup below returns an error, and an early
+	// return that skipped the unlock left the session wedged for good. Close
+	// takes the same lock, so the dialog could not even be torn down.
 	s.rtcpMU.Lock()
+	defer s.rtcpMU.Unlock()
 	writeStats := &s.writeStats
 	// For now we only track latest SSRC
 	if writeStats.SSRC != pkt.SSRC {
@@ -351,7 +355,6 @@ func (s *RTPSession) WriteRTP(pkt *rtp.Packet) error {
 	writeStats.lastPacketTime = time.Now()
 	writeStats.lastPacketTimestamp = pkt.Timestamp
 
-	s.rtcpMU.Unlock()
 	return nil
 }
 

--- a/media/rtp_session_test.go
+++ b/media/rtp_session_test.go
@@ -4,6 +4,7 @@
 package media
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net"
@@ -312,4 +313,37 @@ func TestRTPSessionSourceLockProtection(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, uint16(4), pkt.SequenceNumber)
+}
+
+// TestRTPSessionWriteUnknownPayloadType asserts the session survives a write with
+// a payload type that is not in the codec list. The lookup failure must release
+// the RTCP lock it took, so a later write can still make progress.
+func TestRTPSessionWriteUnknownPayloadType(t *testing.T) {
+	rtpSess := fakeSession(9876, 1234, nil, &bytes.Buffer{}, nil, &bytes.Buffer{})
+	rtpSess.rtcpTicker = time.NewTicker(time.Hour) // DO NOT TICK
+
+	pkt := rtp.Packet{
+		Header: rtp.Header{
+			Version:     2,
+			PayloadType: 111, // not in Codecs
+			SSRC:        1234,
+		},
+		Payload: []byte{1, 2, 3},
+	}
+
+	err := rtpSess.WriteRTP(&pkt)
+	require.Error(t, err)
+
+	// The failed write must not have left rtcpMU held.
+	done := make(chan error, 1)
+	go func() {
+		done <- rtpSess.WriteRTP(&pkt)
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WriteRTP blocked on rtcpMU held by the previous failed write")
+	}
 }


### PR DESCRIPTION
Fixes #152

`WriteRTP` takes `rtcpMU` before updating the write statistics, and the codec lookup inside that critical section returns an error without releasing it. Every later `WriteRTP` then blocks on `rtcpMU`, and `Close` takes the same lock, so the dialog cannot be torn down either — the session is wedged for good.

The lookup is reached only when the packet SSRC differs from the one already in the write statistics, so the first write on a session or an SSRC change, and it fails for any payload type absent from the session codec list.

One line: released on defer.

The test writes a packet whose payload type is absent from the session codec list, then asserts a following write is not blocked. Against the current code it hangs and reports `WriteRTP blocked on rtcpMU held by the previous failed write`.