### PR TITLE
sdp: resolve the media level connection and bound two indexings

### DIFF
--- a/media/sdp/sdp.go
+++ b/media/sdp/sdp.go
@@ -121,12 +121,30 @@ type ConnectionInformation struct {
 	Range       int
 }
 
+// ConnectionInformation returns the connection information that applies to the
+// media stream. Per RFC 4566 section 5.7 a c= inside the media section overrides
+// the session level one, so the last c= wins. Line order alone cannot bind a c=
+// to its section, so this is only sound while the body carries a single m= line,
+// which MediaDescription already requires per RFC 3264. Bodies with more media
+// lines are rejected here as well rather than answering with an address that may
+// belong to another stream.
 func (sd SessionDescription) ConnectionInformation() (ci ConnectionInformation, err error) {
-	v := sd.Value("c")
-	if v == "" {
+	if len(sd.Values("m")) > 1 {
+		return ci, fmt.Errorf("more than 1 media line")
+	}
+
+	values := sd.Values("c")
+	if len(values) == 0 {
 		return ci, fmt.Errorf("Connection information does not exists")
 	}
+	v := values[len(values)-1]
+
 	fields := strings.Fields(v)
+	if len(fields) < 3 {
+		// Body comes from remote peer. Indexing unchecked turns a truncated
+		// c= line into a panic.
+		return ci, fmt.Errorf("sdp - not enough fields in connection information c=%s", v)
+	}
 	ci.NetworkType = fields[0]
 	ci.AddressType = fields[1]
 	addr := strings.Split(fields[2], "/")
@@ -251,8 +269,10 @@ func nextLine(reader *bytes.Buffer) (line string, err error) {
 
 	lenline := len(line)
 
-	// Be tolerant for CRLF
-	if line[lenline-2] == '\r' {
+	// Be tolerant for CRLF.
+	// A bare LF line arrives here as a 1 byte string, so the length must be
+	// checked or this indexes -1 on a body any remote peer can send.
+	if lenline >= 2 && line[lenline-2] == '\r' {
 		return line[:lenline-2], nil
 	}
 

--- a/media/sdp/sdp_connection_test.go
+++ b/media/sdp/sdp_connection_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package sdp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// offer builds an SDP body from lines, CRLF terminated the way a peer sends one.
+func offer(lines ...string) []byte {
+	return []byte(strings.Join(lines, "\r\n") + "\r\n")
+}
+
+// TestConnectionInformationMediaLevel checks RFC 4566 section 5.7 precedence: a
+// c= inside the media section overrides the session level one. A gateway that
+// publishes its signalling address at session level and a separate media address
+// on the audio section is ordinary, and reading the session level c= sends every
+// RTP packet to a host that is not expecting it.
+func TestConnectionInformationMediaLevel(t *testing.T) {
+	body := offer(
+		"v=0",
+		"o=- 1 1 IN IP4 203.0.113.1",
+		"s=-",
+		"c=IN IP4 203.0.113.1", // session level: signalling host
+		"t=0 0",
+		"m=audio 5004 RTP/AVP 8",
+		"c=IN IP4 198.51.100.7", // media level: governs the audio stream
+		"a=rtpmap:8 PCMA/8000",
+	)
+
+	sd := SessionDescription{}
+	require.NoError(t, Unmarshal(body, &sd))
+
+	ci, err := sd.ConnectionInformation()
+	require.NoError(t, err)
+	require.Equal(t, "198.51.100.7", ci.IP.String())
+}
+
+// TestConnectionInformationSessionLevel pins the fallback, which is the common
+// case: most peers publish exactly one session level c=.
+func TestConnectionInformationSessionLevel(t *testing.T) {
+	sd := SessionDescription{}
+	require.NoError(t, Unmarshal(offer(
+		"v=0",
+		"c=IN IP4 203.0.113.9",
+		"t=0 0",
+		"m=audio 5004 RTP/AVP 8",
+		"a=rtpmap:8 PCMA/8000",
+	), &sd))
+
+	ci, err := sd.ConnectionInformation()
+	require.NoError(t, err)
+	require.Equal(t, "203.0.113.9", ci.IP.String())
+}
+
+// TestConnectionInformationMultipleMediaLines documents why taking the last c=
+// is sound. Line order alone cannot bind a c= to its section, so with several m=
+// lines the last c= may belong to some other stream. MediaDescription already
+// rejects that body per RFC 3264, and ConnectionInformation rejects it for the
+// same reason rather than quietly answering with the video section's address.
+func TestConnectionInformationMultipleMediaLines(t *testing.T) {
+	sd := SessionDescription{}
+	require.NoError(t, Unmarshal(offer(
+		"v=0",
+		"c=IN IP4 203.0.113.9",
+		"t=0 0",
+		"m=audio 5004 RTP/AVP 8",
+		"m=video 5006 RTP/AVP 96",
+		"c=IN IP4 192.0.2.44", // video's address, must never govern audio
+	), &sd))
+
+	_, err := sd.ConnectionInformation()
+	require.Error(t, err)
+
+	_, err = sd.MediaDescription("audio")
+	require.Error(t, err)
+}
+
+// TestConnectionInformationMalformed covers a c= line that is truncated before
+// the address. fields[1] and fields[2] were read with no field count guard, so a
+// remote peer sending "c=IN" panicked the process.
+func TestConnectionInformationMalformed(t *testing.T) {
+	for _, v := range []string{"IN", "IN IP4", ""} {
+		sd := SessionDescription{"c": []string{v}}
+		_, err := sd.ConnectionInformation()
+		require.Error(t, err, "c=%s must error, not panic", v)
+	}
+}
+
+// TestUnmarshalMalformedNoPanic pins the parser against bodies a peer can simply
+// send. A bare LF line reached nextLine as a 1 byte string and indexed the CRLF
+// check at -1. There is no recover on the receive path, so either panic takes the
+// process down along with every concurrent call.
+func TestUnmarshalMalformedNoPanic(t *testing.T) {
+	bodies := map[string][]byte{
+		"bare LF line":      []byte("v=0\r\n\nm=audio 5004 RTP/AVP 8\r\n"),
+		"blank line at end": []byte("v=0\r\nm=audio 5004 RTP/AVP 8\r\n\n"),
+		"truncated c=":      []byte("v=0\r\nc=IN\r\nm=audio 5004 RTP/AVP 8\r\n"),
+		"empty c=":          []byte("v=0\r\nc=\r\nm=audio 5004 RTP/AVP 8\r\n"),
+		"media truncated c=": []byte("v=0\r\nc=IN IP4 203.0.113.1\r\n" +
+			"m=audio 5004 RTP/AVP 8\r\nc=IN IP4\r\n"),
+		"empty body": {},
+		"lone LF":    []byte("\n"),
+		"lone CR":    []byte("\r"),
+	}
+
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			// An error is an acceptable outcome for all of these. A panic is not.
+			sd := SessionDescription{}
+			_ = Unmarshal(body, &sd)
+			_, _ = sd.ConnectionInformation()
+			_, _ = sd.MediaDescription("audio")
+		})
+	}
+}


### PR DESCRIPTION
Fixes #154

`ConnectionInformation` read the first `c=`, so a `c=` inside the media section did not override the session-level one as RFC 4566 section 5.7 requires. Both callers in `media/media_session.go` use that address as the RTP destination, so against a peer whose media section carries its own `c=` the RTP goes to the signalling host. The last `c=` is taken instead.

That is only sound while the body carries a single `m=` line, since line order alone cannot bind a `c=` to its section. `MediaDescription` already rejects multi-`m=` bodies after `9f38abc`; `ConnectionInformation` rejects them here as well rather than answering with an address that may belong to another stream.

Two indexings are bounded — `fields[1]`/`fields[2]` of the `c=` line, and `line[lenline-2]` in `nextLine` where a bare LF line arrives as a 1-byte string and indexes -1. Both are reachable from any remote body with no `recover` on the path; against current code the tests panic with `index out of range [1] with length 1`.

One note: `webrtc-pion` already carries an equivalent `nextLine` guard, so if that branch is landing you may prefer only the `ConnectionInformation` half. Happy to cut it down.

`TestRTPJitterBufferOverflow` fails in `media/` both with and without this change — pre-existing on main, untouched here.