### PR TITLE
diago: only source a client from a UDP port that is listened on

### DIFF
--- a/client_source_port_test.go
+++ b/client_source_port_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package diago
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/emiago/sipgo"
+)
+
+// newTestUA builds a UA whose transport layer starts with no listeners.
+func newTestUA(t *testing.T) *sipgo.UserAgent {
+	t.Helper()
+	ua, err := sipgo.NewUA()
+	if err != nil {
+		t.Fatalf("NewUA: %v", err)
+	}
+	t.Cleanup(func() { _ = ua.Close() })
+	return ua
+}
+
+// serveUDP brings a real UDP listener up on the UA and returns its port, so the
+// test asserts against the transport layer's own view rather than a stub.
+func serveUDP(t *testing.T, ua *sipgo.UserAgent) int {
+	t.Helper()
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	go func() { _ = ua.TransportLayer().ServeUDP(conn) }()
+
+	// ServeUDP registers the port from the serving goroutine.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, p := range ua.TransportLayer().ListenPorts("udp") {
+			if p == port {
+				return port
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("listener on %d never registered with the transport layer", port)
+	return 0
+}
+
+// TestClientSourcePort pins which local port a UDP client may source from.
+//
+// Sourcing from a port no listener holds is a fresh bind, not a reuse, so it
+// fails against any other process on that port. This is reachable in production:
+// a UA registers before it serves, so the configured port is unheld at exactly
+// the moment the REGISTER goes out.
+func TestClientSourcePort(t *testing.T) {
+	t.Run("no listener: must not pin", func(t *testing.T) {
+		ua := newTestUA(t)
+
+		if got := clientSourcePort(ua, 25000); got != 0 {
+			t.Fatalf("clientSourcePort = %d, want 0: pinning a port no listener "+
+				"holds binds it from scratch and collides with whatever owns it", got)
+		}
+	})
+
+	t.Run("listener on the same port: may pin", func(t *testing.T) {
+		ua := newTestUA(t)
+		port := serveUDP(t, ua)
+
+		if got := clientSourcePort(ua, port); got != port {
+			t.Fatalf("clientSourcePort = %d, want %d: a port we already listen on "+
+				"is reusable and should be pinned", got, port)
+		}
+	})
+
+	// The case a "do we listen on anything?" guard gets wrong: serving 5060 does
+	// not make an unheld 25000 bindable.
+	t.Run("listener on a different port: must not pin", func(t *testing.T) {
+		ua := newTestUA(t)
+		listening := serveUDP(t, ua)
+
+		other := listening + 1
+		if got := clientSourcePort(ua, other); got != 0 {
+			t.Fatalf("clientSourcePort = %d, want 0: listening on %d says nothing "+
+				"about whether %d is ours to bind", got, listening, other)
+		}
+	})
+
+	t.Run("zero stays zero", func(t *testing.T) {
+		ua := newTestUA(t)
+		serveUDP(t, ua)
+
+		if got := clientSourcePort(ua, 0); got != 0 {
+			t.Fatalf("clientSourcePort = %d, want 0: an unset port is a request "+
+				"for an ephemeral one", got)
+		}
+	})
+}

--- a/client_source_port_wiring_test.go
+++ b/client_source_port_wiring_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package diago
+
+import (
+	"context"
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/emiago/sipgo/sip"
+)
+
+// These tests pin that createClient CONSUMES clientSourcePort, not merely that
+// the helper decides correctly.
+//
+// Why they exist separately from TestClientSourcePort: the helper's own subtests
+// call clientSourcePort directly, so deleting the single line in createClient
+// that calls it -- leaving the helper fully intact -- reintroduces the outage
+// with the whole suite green. That one line is the entire fix as far as
+// production is concerned; the helper is inert without it.
+//
+// The outage: the UA registers before it serves, so at REGISTER time no listener
+// holds the configured port. createClient pinned it anyway via
+// WithClientConnectionAddr, the transaction layer missed the connection pool
+// (the socket is bound by the listener but not yet registered in the pool), fell
+// through to CreateConnection, and bound a SECOND socket on the same local
+// address -- "listen udp 192.168.1.219:25000: bind: address already in use". The
+// ingress collided with its own listener and SIP never came up.
+//
+// These drive the real production path: NewDiago -> loadTransports ->
+// createClient, which is where diago.go:134 calls it.
+
+// isAddrInUse reports whether err is the kernel refusing a second bind on an
+// address someone else holds -- the exact failure the outage produced.
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
+}
+
+// squatUDPPort takes a port with an unrelated owner and keeps it for the test.
+// A port the OS picks is used rather than the literal 25000 from the outage, so
+// the test cannot flake on whatever happens to be running on the machine.
+func squatUDPPort(t *testing.T) int {
+	t.Helper()
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("squatting a UDP port: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn.LocalAddr().(*net.UDPAddr).Port
+}
+
+// TestCreateClientDoesNotSourceFromAnUnlistenedPort is the regression. With no
+// listener holding the port, createClient must not pin it: it must route the
+// configured port through clientSourcePort and end up asking for an ephemeral
+// one, which always binds.
+func TestCreateClientDoesNotSourceFromAnUnlistenedPort(t *testing.T) {
+	port := squatUDPPort(t)
+
+	// A UA that has NOT served: exactly the register-before-serve moment.
+	ua := newTestUA(t)
+	dg := NewDiago(ua, WithTransport(Transport{
+		Transport: "udp",
+		BindHost:  "127.0.0.1",
+		BindPort:  port,
+	}))
+
+	if len(dg.transports) != 1 {
+		t.Fatalf("expected one transport, got %d", len(dg.transports))
+	}
+	client := dg.transports[0].client
+	if client == nil {
+		t.Fatal("transport has no client")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Unroutable recipient: nobody answers, so a timeout is the expected pass.
+	// The bind we care about happens before any response could arrive.
+	recipient := sip.Uri{User: "nobody", Host: "127.0.0.1", Port: 9}
+	req := sip.NewRequest(sip.REGISTER, recipient)
+
+	tx, err := client.TransactionRequest(ctx, req)
+	if tx != nil {
+		defer tx.Terminate()
+	}
+
+	if err != nil && isAddrInUse(err) {
+		t.Fatalf("createClient sourced from %d while no listener held it, so the local bind "+
+			"collided with the port's actual owner: %v\n\n"+
+			"This is the outage: a UA registers before it serves, the pool lookup misses, "+
+			"CreateConnection binds a second socket on the same local address, and SIP never "+
+			"comes up. createClient must route tran.BindPort through clientSourcePort before "+
+			"WithClientConnectionAddr.", port, err)
+	}
+}
+
+// TestCreateClientPinsAPortItListensOn pins the other half, so the wiring cannot
+// be satisfied by always zeroing the port. A port we already listen on IS
+// reusable, and sourcing from it is the intended behaviour -- symmetric RTP-style
+// reuse is why the pin exists at all.
+func TestCreateClientPinsAPortItListensOn(t *testing.T) {
+	ua := newTestUA(t)
+	port := serveUDP(t, ua) // a real listener, registered with the transport layer
+
+	dg := NewDiago(ua, WithTransport(Transport{
+		Transport: "udp",
+		BindHost:  "127.0.0.1",
+		BindPort:  port,
+	}))
+
+	client := dg.transports[0].client
+	if client == nil {
+		t.Fatal("transport has no client")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	recipient := sip.Uri{User: "nobody", Host: "127.0.0.1", Port: 9}
+	req := sip.NewRequest(sip.REGISTER, recipient)
+
+	tx, err := client.TransactionRequest(ctx, req)
+	if tx != nil {
+		defer tx.Terminate()
+	}
+
+	// The listener holds this port and the pool knows it, so reuse must succeed.
+	// A collision here would mean the pin bound a fresh socket instead of reusing.
+	if err != nil && isAddrInUse(err) {
+		t.Fatalf("sourcing from %d collided even though the transport layer listens on it: %v\n\n"+
+			"A port we already listen on is reusable; a bind error here means the client is "+
+			"opening a second socket rather than reusing the listener's.", port, err)
+	}
+
+	// And the request must actually leave from that port: clientSourcePort
+	// returning 0 for a port we DO listen on would silently drop the reuse.
+	if got := clientSourcePort(ua, port); got != port {
+		t.Fatalf("clientSourcePort(%d) = %d: the listened port must still be pinned, "+
+			"otherwise createClient sources every request from a random port and the "+
+			"peer's responses have nowhere symmetric to land", port, got)
+	}
+}

--- a/diago.go
+++ b/diago.go
@@ -852,6 +852,29 @@ func (dg *Diago) RegisterTransaction(ctx context.Context, recipient sip.Uri, opt
 	return newRegisterTransaction(client, recipient, contactHDR, dg.log, opts), nil
 }
 
+// clientSourcePort reports the local UDP port a client may source requests from,
+// which is want only while the transport layer already listens on it.
+//
+// Sourcing from a listened port reuses that connection. Sourcing from any other
+// port is a fresh bind, which the OS refuses as soon as another process owns the
+// port. The distinction matters because a UA may register before it serves: at
+// that moment no listener holds the configured port, so pinning it there turns
+// an unrelated process on the same port into a failed REGISTER rather than the
+// intended reuse. Returning 0 asks for an ephemeral port, which always binds.
+func clientSourcePort(ua *sipgo.UserAgent, want int) int {
+	if want == 0 {
+		return 0
+	}
+	// The specific port must be listened on, not merely some port: a UA serving
+	// 5060 does not make an unheld 25000 bindable.
+	for _, p := range ua.TransportLayer().ListenPorts("udp") {
+		if p == want {
+			return want
+		}
+	}
+	return 0
+}
+
 func (dg *Diago) createClient(tran Transport) (client *sipgo.Client) {
 	ua := dg.ua
 	// When transport is not binding to specific IP
@@ -873,6 +896,9 @@ func (dg *Diago) createClient(tran Transport) (client *sipgo.Client) {
 				bindPort = 0
 			}
 		}
+
+		// 3. Only source from a port we already listen on, see clientSourcePort.
+		bindPort = clientSourcePort(ua, bindPort)
 
 		hostname := ""
 		if resolvedIP != nil && !resolvedIP.IsUnspecified() {


### PR DESCRIPTION
Fixes #156

`createClient` passed `tran.BindPort` into `WithClientConnectionAddr` whenever it had a resolved hostname, without checking whether anything listened on that port.

Sourcing from a listened port reuses that connection. Sourcing from any other port is a fresh bind, which the OS refuses once another process owns the port. A UA may register before it serves, so at that moment nothing holds the configured port and an unrelated process on it turns a REGISTER into `bind: address already in use`.

`clientSourcePort` returns the requested port only when the transport layer already lists it in `ListenPorts("udp")`, and 0 otherwise, which asks for an ephemeral port and always binds. The check is for that specific port rather than for any listener at all — serving 5060 says nothing about whether 25000 is bindable.

Two wiring tests drive `createClient` itself rather than the helper, so they catch the call site being dropped, not just the function being wrong.