### PR TITLE
media: resolve a G.722 offer that carries no a=rtpmap

### DIFF
--- a/media/codec.go
+++ b/media/codec.go
@@ -20,6 +20,12 @@ var (
 	CodecAudioAlaw          = Codec{PayloadType: 8, SampleRate: 8000, SampleDur: 20 * time.Millisecond, NumChannels: 1, Name: "PCMA"}
 	CodecAudioOpus          = Codec{PayloadType: 96, SampleRate: 48000, SampleDur: 20 * time.Millisecond, NumChannels: 2, Name: "opus"}
 	CodecTelephoneEvent8000 = Codec{PayloadType: 101, SampleRate: 8000, SampleDur: 20 * time.Millisecond, NumChannels: 1, Name: "telephone-event"}
+
+	// CodecAudioG722 SampleRate is 8000 and not 16000. RFC 3551 section 4.5.2 froze
+	// the G.722 RTP clock at 8000 even though the codec samples at 16 kHz. The clock
+	// drives SampleTimestamp(), so 16000 here would advance the RTP timestamp at
+	// twice the wire rate. The 16 kHz sampling rate is a decoder concern only.
+	CodecAudioG722 = Codec{PayloadType: 9, SampleRate: 8000, SampleDur: 20 * time.Millisecond, NumChannels: 1, Name: "G722"}
 )
 
 type Codec struct {
@@ -88,6 +94,8 @@ func CodecAudioFromPayloadType(payloadType uint8) (Codec, error) {
 		return CodecAudioAlaw, nil
 	case sdp.FORMAT_TYPE_ULAW:
 		return CodecAudioUlaw, nil
+	case sdp.FORMAT_TYPE_G722:
+		return CodecAudioG722, nil
 	case sdp.FORMAT_TYPE_OPUS:
 		return CodecAudioOpus, nil
 	case sdp.FORMAT_TYPE_TELEPHONE_EVENT:
@@ -104,6 +112,8 @@ func mapSupportedCodec(f string) Codec {
 		return CodecAudioAlaw
 	case sdp.FORMAT_TYPE_ULAW:
 		return CodecAudioUlaw
+	case sdp.FORMAT_TYPE_G722:
+		return CodecAudioG722
 	case sdp.FORMAT_TYPE_OPUS:
 		return CodecAudioOpus
 	case sdp.FORMAT_TYPE_TELEPHONE_EVENT:
@@ -153,6 +163,16 @@ func CodecsFromSDPRead(formats []string, attrs []string, codecsAudio []Codec) (i
 
 		if f == "8" {
 			codecsAudio[n] = CodecAudioAlaw
+			n++
+			continue
+		}
+
+		// G.722 is a static payload type like ulaw and alaw above, so a peer may
+		// offer it with no a=rtpmap line. Resolving it from the payload type also
+		// keeps the RFC 3551 clock when a peer advertises the 16 kHz sampling rate
+		// in rtpmap instead.
+		if f == "9" {
+			codecsAudio[n] = CodecAudioG722
 			n++
 			continue
 		}

--- a/media/codec_g722_test.go
+++ b/media/codec_g722_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package media
+
+import (
+	"net"
+	"testing"
+
+	"github.com/emiago/diago/media/sdp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodecG722Clock(t *testing.T) {
+	// RFC 3551 froze the G.722 RTP clock at 8000 even though the codec samples at
+	// 16 kHz. 8000 * 20ms = 160 ticks per packet.
+	assert.EqualValues(t, 8000, CodecAudioG722.SampleRate)
+	assert.EqualValues(t, 160, CodecAudioG722.SampleTimestamp())
+
+	// DTMF writer rejects any codec that is not on the 8000 clock, so
+	// telephone-event must share the G.722 clock.
+	assert.Equal(t, CodecTelephoneEvent8000.SampleRate, CodecAudioG722.SampleRate)
+}
+
+func TestCodecG722FromPayloadType(t *testing.T) {
+	codec, err := CodecAudioFromPayloadType(9)
+	require.NoError(t, err)
+	assert.Equal(t, CodecAudioG722, codec)
+
+	assert.Equal(t, CodecAudioG722, mapSupportedCodec(sdp.FORMAT_TYPE_G722))
+}
+
+func TestCodecG722SDPRtpmap(t *testing.T) {
+	codecs := []Codec{CodecAudioG722, CodecTelephoneEvent8000}
+	ip := net.IPv4(127, 0, 0, 1)
+	out := string(generateSDPForAudio(1, 1, "RTP/AVP", ip, ip, 10000, sdp.ModeSendrecv, codecs, sdesInline{}, nil))
+
+	assert.Contains(t, out, "m=audio 10000 RTP/AVP 9 101")
+	assert.Contains(t, out, "a=rtpmap:9 G722/8000")
+	// Clock must never be the 16 kHz sampling rate and the line must not carry the
+	// encoding parameters suffix the generic default would append.
+	assert.NotContains(t, out, "G722/16000")
+	assert.NotContains(t, out, "G722/8000/1")
+	assert.Contains(t, out, "a=rtpmap:101 telephone-event/8000")
+}
+
+func TestCodecsFromSDPReadG722Static(t *testing.T) {
+	// G.722 is a static payload type, so a peer may offer bare RTP/AVP 9 with no
+	// a=rtpmap line at all.
+	codecs := make([]Codec, 4)
+	n, err := CodecsFromSDPRead([]string{"9"}, nil, codecs)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	assert.Equal(t, CodecAudioG722, codecs[0])
+
+	// Mixed static only offer, still no rtpmap.
+	codecs = make([]Codec, 4)
+	n, err = CodecsFromSDPRead([]string{"0", "8", "9"}, nil, codecs)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	assert.Equal(t, []Codec{CodecAudioUlaw, CodecAudioAlaw, CodecAudioG722}, codecs[:n])
+
+	// A peer that mislabels the rtpmap clock must not desynchronize us: the static
+	// payload type wins and keeps the RFC 3551 clock.
+	codecs = make([]Codec, 4)
+	n, err = CodecsFromSDPRead([]string{"9"}, []string{"rtpmap:9 G722/16000"}, codecs)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	assert.EqualValues(t, 8000, codecs[0].SampleRate)
+}

--- a/media/media_session.go
+++ b/media/media_session.go
@@ -1169,6 +1169,11 @@ func generateSDPForAudio(sessionID uint64, sessionVersion uint64, rtpProfile str
 			formatsMap = append(formatsMap, "a=rtpmap:0 PCMU/8000")
 		case CodecAudioAlaw.PayloadType:
 			formatsMap = append(formatsMap, "a=rtpmap:8 PCMA/8000")
+		case CodecAudioG722.PayloadType:
+			// Clock is 8000 per RFC 3551 and the encoding parameters suffix is
+			// omitted. The generic default below would append the channel count and
+			// some peers do not match the non canonical form.
+			formatsMap = append(formatsMap, "a=rtpmap:9 G722/8000")
 		case CodecAudioOpus.PayloadType:
 			formatsMap = append(formatsMap, "a=rtpmap:96 opus/48000/2")
 			// Providing 0 when FEC cannot be used on the receiving side is RECOMMENDED.

--- a/media/sdp/formats.go
+++ b/media/sdp/formats.go
@@ -11,6 +11,7 @@ import (
 const (
 	FORMAT_TYPE_ULAW            = "0"
 	FORMAT_TYPE_ALAW            = "8"
+	FORMAT_TYPE_G722            = "9"
 	FORMAT_TYPE_OPUS            = "96"
 	FORMAT_TYPE_TELEPHONE_EVENT = "101"
 )
@@ -43,6 +44,8 @@ func (fmts Formats) String() string {
 			out[i] = "0(ulaw)"
 		case FORMAT_TYPE_ALAW:
 			out[i] = "8(alaw)"
+		case FORMAT_TYPE_G722:
+			out[i] = "9(g722)"
 		case FORMAT_TYPE_OPUS:
 			out[i] = "96(opus)"
 		default:

--- a/media/sdp/utils.go
+++ b/media/sdp/utils.go
@@ -36,6 +36,9 @@ func GenerateForAudio(originIP net.IP, connectionIP net.IP, rtpPort int, mode st
 			formatsMap = append(formatsMap, "a=rtpmap:0 PCMU/8000")
 		case FORMAT_TYPE_ALAW:
 			formatsMap = append(formatsMap, "a=rtpmap:8 PCMA/8000")
+		case FORMAT_TYPE_G722:
+			// Clock is 8000 per RFC 3551, see generateSDPForAudio.
+			formatsMap = append(formatsMap, "a=rtpmap:9 G722/8000")
 		case FORMAT_TYPE_OPUS:
 			formatsMap = append(formatsMap, "a=rtpmap:96 opus/48000/2")
 			// Providing 0 when FEC cannot be used on the receiving side is RECOMMENDED.


### PR DESCRIPTION
Fixes #158

RFC 3551 section 6 assigns G.722 the static payload type 9, so `m=audio <port> RTP/AVP 9` with no `a=rtpmap` is a conformant offer. `CodecsFromSDPRead` only appends a codec from inside the `a=rtpmap` branch apart from the static fast paths for 0 and 8, so that offer resolves zero codecs and `RemoteSDP` returns `no codecs found in SDP`. The call is rejected, and there is no caller-side workaround since `CodecsFromSDPRead` is unexported.

Adds `CodecAudioG722` and `FORMAT_TYPE_G722`, plus an arm for 9 on the static path — placed before the rtpmap loop so a peer advertising `G722/16000` does not override the clock.

On that clock: RFC 3551 section 4.5.2 sets the RTP clock for G.722 to 8000 even though the codec samples at 16 kHz. `SampleTimestamp()` is `SampleRate * SampleDur`, so 16000 would advance the RTP timestamp at twice the wire rate.

Both SDP generators get an explicit `a=rtpmap:9 G722/8000` arm rather than the generic default, which formats as `%d %s/%d/%d` and would emit `G722/8000/1` — some peers do not match the channel-count suffix.

**The default codec set is unchanged**, so G.722 only negotiates when a caller puts it in `MediaConfig.Codecs` — same as opus today. This is the negotiation constant and SDP plumbing only; it does not claim `audio.PCMDecoder` support, which is the same position `CodecAudioOpus` is already in on a default build.