### PR TITLE
dialog: report the terminal REFER outcome instead of the 202

### DIFF
--- a/dialog_client_session.go
+++ b/dialog_client_session.go
@@ -568,6 +568,9 @@ func (d *DialogClientSession) reInviteKeepAlive(ctx context.Context) error {
 
 // Refer tries todo refer (blind transfer) on call. For more control use ReferOptions
 //
+// It blocks until the transfer outcome is known: the terminal sipfrag NOTIFY, or
+// a 30s deadline. A transfer that did not succeed returns *ReferFailureError.
+//
 // NOTE: It is expected that after calling this you are hanguping call to send BYE
 func (d *DialogClientSession) Refer(ctx context.Context, referTo sip.Uri, headers ...sip.Header) error {
 	// cont := d.InviteRequest.Contact()
@@ -581,9 +584,14 @@ type ReferClientOptions struct {
 	Headers []sip.Header
 	// OnNotify sends notify status code.
 	// If implemented you need to react on different status code.
+	// Setting this returns from refer as soon as it is accepted, leaving the
+	// transfer outcome to the callback.
 	OnNotify func(statusCode int)
 }
 
+// ReferOptions sends a REFER. With OnNotify set it returns once the REFER is
+// accepted and reports outcomes to the callback. Without one it blocks for the
+// transfer outcome and returns *ReferFailureError if it did not succeed.
 func (d *DialogClientSession) ReferOptions(ctx context.Context, referTo sip.Uri, opts ReferClientOptions) error {
 	d.mu.Lock()
 	cont := d.remoteContactUnsafe()
@@ -591,7 +599,7 @@ func (d *DialogClientSession) ReferOptions(ctx context.Context, referTo sip.Uri,
 		d.onReferNotify = opts.OnNotify
 	}
 	d.mu.Unlock()
-	return dialogRefer(ctx, d, cont.Address, referTo, d.InviteResponse.Contact().Address, opts.Headers...)
+	return dialogRefer(ctx, d, cont.Address, referTo, d.InviteResponse.Contact().Address, opts.OnNotify == nil, opts.Headers...)
 }
 
 func (d *DialogClientSession) handleReferNotify(req *sip.Request, tx sip.ServerTransaction) {

--- a/dialog_media.go
+++ b/dialog_media.go
@@ -74,10 +74,90 @@ type DialogMedia struct {
 
 	onReferNotify func(statusCode int)
 
+	// referMu guards referInFlight. It is separate from mu so delivering a REFER
+	// outcome never contends with media state.
+	referMu sync.Mutex
+	// referInFlight is the waiter for the REFER attempt currently awaiting its
+	// terminal sipfrag NOTIFY, or nil when no synchronous transfer is in flight.
+	// Only dialogRefer callers that opted into waiting register one; the
+	// onReferNotify callback path leaves this nil.
+	referInFlight *referWaiter
+
 	onClose       func() error
 	onMediaUpdate func(*DialogMedia)
 
 	closed bool
+}
+
+// referWaiter is one in-flight REFER attempt's terminal-outcome mailbox. ch is
+// buffered so dialogHandleReferNotify never blocks delivering an outcome, even
+// if the waiter has already given up on the deadline.
+type referWaiter struct {
+	// cseq is the CSeq of the sent REFER. RFC 3515 makes the NOTIFY's Event id
+	// the CSeq of the REFER that created the subscription, so this is what an
+	// id-carrying NOTIFY is matched against.
+	cseq uint32
+	// cseqKnown is false until setReferAttemptCSeq records the sent REFER's CSeq.
+	// Until then an id-carrying NOTIFY cannot be rejected as stale.
+	cseqKnown bool
+	// ch carries the terminal outcome to the dialogRefer waiter.
+	ch chan referTerminal
+}
+
+// beginReferAttempt registers a fresh in-flight REFER waiter, replacing any
+// prior one, and returns it. Called before the REFER is sent so a terminal
+// NOTIFY that races ahead of the wait is buffered rather than lost.
+func (d *DialogMedia) beginReferAttempt() *referWaiter {
+	w := &referWaiter{ch: make(chan referTerminal, 1)}
+	d.referMu.Lock()
+	d.referInFlight = w
+	d.referMu.Unlock()
+	return w
+}
+
+// setReferAttemptCSeq records the sent REFER's CSeq on w, but only while w is
+// still the registered attempt, so it can never stamp a newer one.
+func (d *DialogMedia) setReferAttemptCSeq(w *referWaiter, cseq uint32) {
+	d.referMu.Lock()
+	if d.referInFlight == w {
+		w.cseq = cseq
+		w.cseqKnown = true
+	}
+	d.referMu.Unlock()
+}
+
+// endReferAttempt unregisters w, but only if it is still the registered attempt.
+// dialogRefer defers this on every return path so a late NOTIFY for a finished
+// attempt finds no waiter and can never be inherited by a later attempt on the
+// same still-live dialog.
+func (d *DialogMedia) endReferAttempt(w *referWaiter) {
+	d.referMu.Lock()
+	if d.referInFlight == w {
+		d.referInFlight = nil
+	}
+	d.referMu.Unlock()
+}
+
+// deliverReferResult routes a terminal sipfrag outcome to the in-flight REFER
+// waiter, if any. A NOTIFY carrying an RFC 3515 Event id is delivered only when
+// that id matches the in-flight attempt's CSeq, so a stale NOTIFY from a prior
+// REFER on the same dialog is dropped. A NOTIFY without an id falls back to the
+// single in-flight attempt, since peers MAY omit it. The send is non-blocking so
+// a NOTIFY handler is never held up by a waiter that has already timed out.
+func (d *DialogMedia) deliverReferResult(notifyID uint32, hasID bool, term referTerminal) {
+	d.referMu.Lock()
+	defer d.referMu.Unlock()
+	w := d.referInFlight
+	if w == nil {
+		return
+	}
+	if hasID && w.cseqKnown && notifyID != w.cseq {
+		return
+	}
+	select {
+	case w.ch <- term:
+	default:
+	}
 }
 
 func (d *DialogMedia) Close() error {

--- a/dialog_server_session.go
+++ b/dialog_server_session.go
@@ -478,6 +478,9 @@ func (d *DialogServerSession) remoteContactUnsafe() *sip.ContactHeader {
 
 // Refer tries todo refer (blind transfer) on call. For more control use ReferOptions
 //
+// It blocks until the transfer outcome is known: the terminal sipfrag NOTIFY, or
+// a 30s deadline. A transfer that did not succeed returns *ReferFailureError.
+//
 // NOTE: It is expected that after calling this you are hanguping call to send BYE
 func (d *DialogServerSession) Refer(ctx context.Context, referTo sip.Uri, headers ...sip.Header) error {
 	// cont := d.InviteRequest.Contact()
@@ -488,10 +491,16 @@ func (d *DialogServerSession) Refer(ctx context.Context, referTo sip.Uri, header
 }
 
 type ReferServerOptions struct {
-	Headers  []sip.Header
+	Headers []sip.Header
+	// OnNotify sends notify status code.
+	// Setting this returns from refer as soon as it is accepted, leaving the
+	// transfer outcome to the callback.
 	OnNotify func(statusCode int)
 }
 
+// ReferOptions sends a REFER. With OnNotify set it returns once the REFER is
+// accepted and reports outcomes to the callback. Without one it blocks for the
+// transfer outcome and returns *ReferFailureError if it did not succeed.
 func (d *DialogServerSession) ReferOptions(ctx context.Context, referTo sip.Uri, opts ReferServerOptions) error {
 	d.mu.Lock()
 	cont := d.remoteContactUnsafe()
@@ -499,7 +508,7 @@ func (d *DialogServerSession) ReferOptions(ctx context.Context, referTo sip.Uri,
 		d.onReferNotify = opts.OnNotify
 	}
 	d.mu.Unlock()
-	return dialogRefer(ctx, d, cont.Address, referTo, d.InviteResponse.Contact().Address, opts.Headers...)
+	return dialogRefer(ctx, d, cont.Address, referTo, d.InviteResponse.Contact().Address, opts.OnNotify == nil, opts.Headers...)
 }
 
 func (d *DialogServerSession) handleReferNotify(req *sip.Request, tx sip.ServerTransaction) {

--- a/dialog_session.go
+++ b/dialog_session.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/emiago/sipgo"
 	"github.com/emiago/sipgo/sip"
@@ -24,13 +25,117 @@ type DialogSession interface {
 	Close() error
 }
 
+// referAnswerDeadline bounds how long a waiting dialogRefer blocks for the
+// terminal sipfrag NOTIFY after the 202 Accepted. A 202 only acknowledges that
+// the recipient accepted the REFER for processing; the transfer outcome arrives
+// asynchronously. Package var so tests can shrink it.
+var referAnswerDeadline = 30 * time.Second
+
+// ReferFailureError is returned by a waiting Refer when a blind transfer does not
+// complete successfully: either a terminal sipfrag NOTIFY carried a non-2xx
+// status, or no terminal sipfrag arrived within referAnswerDeadline. It carries
+// only the numeric SIP status and a short reason phrase — never Via/Contact/host
+// or other routing internals — so a caller can classify the outcome (busy /
+// unavailable / rejected) without risk of leaking SIP internals.
+type ReferFailureError struct {
+	// Status is the SIP status from the terminal sipfrag (e.g. 486). It is 0 when
+	// the failure is a timeout with no terminal sipfrag received.
+	Status int
+	// Reason is a short, non-sensitive phrase from the sipfrag status line
+	// (e.g. "Busy Here"), or "timeout"/"cancelled". Classify on Status, not this.
+	Reason string
+}
+
+// Error renders the failure without any SIP routing internals.
+func (e *ReferFailureError) Error() string {
+	if e.Status == 0 {
+		return fmt.Sprintf("refer transfer failed: %s", e.Reason)
+	}
+	return fmt.Sprintf("refer transfer failed: %d %s", e.Status, e.Reason)
+}
+
+// referTerminal carries a REFER outcome parsed from a sipfrag NOTIFY status
+// line, from dialogHandleReferNotify to a dialogRefer waiter.
+type referTerminal struct {
+	status int
+	reason string
+}
+
+// parseSipfragStatus parses the status code and reason phrase from a
+// message/sipfrag status line of the form "SIP/2.0 <code> <reason>" (the shape
+// sendNotify writes). Only the first line is the status line. It returns
+// ok=false when the line is malformed or the code is not a valid SIP status, so
+// an untrusted NOTIFY body can never be mistaken for a terminal outcome.
+func parseSipfragStatus(frag string) (status int, reason string, ok bool) {
+	line := frag
+	if i := strings.IndexAny(frag, "\r\n"); i >= 0 {
+		line = frag[:i]
+	}
+	const prefix = "SIP/2.0 "
+	if !strings.HasPrefix(line, prefix) {
+		return 0, "", false
+	}
+	rest := strings.TrimSpace(line[len(prefix):])
+	codeStr := rest
+	if sp := strings.IndexByte(rest, ' '); sp >= 0 {
+		codeStr = rest[:sp]
+		reason = strings.TrimSpace(rest[sp+1:])
+	}
+	code, err := strconv.Atoi(codeStr)
+	if err != nil || code < 100 || code > 699 {
+		return 0, "", false
+	}
+	return code, reason, true
+}
+
+// parseReferNotifyEventID extracts the RFC 3515 subscription id from a REFER
+// NOTIFY's Event header value of the form "refer;id=<n>". sipgo exposes no typed
+// Event header, so the generic value is parsed here. Peers MAY omit ;id, so
+// hasID=false is a normal case.
+func parseReferNotifyEventID(req *sip.Request) (id uint32, hasID bool) {
+	h := req.GetHeader("Event")
+	if h == nil {
+		return 0, false
+	}
+	// The value is "<event-type>[;param=value]*"; scan the params for id=.
+	for _, part := range strings.Split(h.Value(), ";") {
+		part = strings.TrimSpace(part)
+		const idPrefix = "id="
+		if !strings.HasPrefix(part, idPrefix) {
+			continue
+		}
+		n, err := strconv.ParseUint(strings.TrimSpace(part[len(idPrefix):]), 10, 32)
+		if err != nil {
+			return 0, false
+		}
+		return uint32(n), true
+	}
+	return 0, false
+}
+
 //
 // Here are many common functions built for dialog
 //
 
-func dialogRefer(ctx context.Context, d DialogSession, recipient sip.Uri, referTo sip.Uri, refferedBy sip.Uri, headers ...sip.Header) error {
+// dialogRefer sends a REFER and returns once it is accepted. When wait is true it
+// additionally blocks for the terminal sipfrag NOTIFY (bounded by
+// referAnswerDeadline) and reports the real transfer outcome as a
+// *ReferFailureError, rather than reporting the 202 as success. Callers that
+// supply an OnNotify callback observe the outcome asynchronously instead and pass
+// wait=false.
+func dialogRefer(ctx context.Context, d DialogSession, recipient sip.Uri, referTo sip.Uri, refferedBy sip.Uri, wait bool, headers ...sip.Header) error {
 	if d.DialogSIP().LoadState() != sip.DialogStateConfirmed {
 		return fmt.Errorf("can only be called on answered dialog")
+	}
+
+	// Register the waiter BEFORE sending so a terminal sipfrag NOTIFY that races
+	// ahead of the park below is buffered on it, not lost. Unregister on every
+	// return path so a late NOTIFY for this finished attempt finds no waiter and
+	// cannot be inherited by a later attempt on the same still-live dialog.
+	var waiter *referWaiter
+	if wait {
+		waiter = d.Media().beginReferAttempt()
+		defer d.Media().endReferAttempt(waiter)
 	}
 
 	req := sip.NewRequest(sip.REFER, recipient)
@@ -57,12 +162,48 @@ func dialogRefer(ctx context.Context, d DialogSession, recipient sip.Uri, referT
 		return err
 	}
 
+	// Record the sent REFER's CSeq (assigned by the dialog during Do) so a NOTIFY
+	// carrying an RFC 3515 Event id can be correlated to THIS attempt. Peers that
+	// omit the id fall back to single-in-flight correlation.
+	if waiter != nil {
+		if cseq := req.CSeq(); cseq != nil {
+			d.Media().setReferAttemptCSeq(waiter, cseq.SeqNo)
+		}
+	}
+
 	if res.StatusCode != sip.StatusAccepted {
 		return sipgo.ErrDialogResponse{
 			Res: res,
 		}
 	}
-	return nil
+
+	if waiter == nil {
+		return nil
+	}
+
+	// The 202 only says the REFER was accepted for processing — the real outcome
+	// arrives asynchronously as a terminal sipfrag NOTIFY handled by
+	// dialogHandleReferNotify. Block for it so the caller learns the truthful
+	// result instead of a premature success.
+	waitCtx, cancel := context.WithTimeout(ctx, referAnswerDeadline)
+	defer cancel()
+
+	select {
+	case term := <-waiter.ch:
+		if term.status < 300 {
+			return nil
+		}
+		return &ReferFailureError{Status: term.status, Reason: term.reason}
+	case <-waitCtx.Done():
+		// Distinguish a genuine answer-supervision timeout from a cancelled parent
+		// context (the call was torn down under us) for diagnostic accuracy. Both
+		// classify as a Status-0 failure.
+		reason := "timeout"
+		if ctx.Err() != nil {
+			reason = "cancelled"
+		}
+		return &ReferFailureError{Status: 0, Reason: reason}
+	}
 }
 
 func dialogHandleReferNotify(d DialogSession, req *sip.Request, tx sip.ServerTransaction) {
@@ -80,6 +221,15 @@ func dialogHandleReferNotify(d DialogSession, req *sip.Request, tx sip.ServerTra
 		return
 	}
 
+	// A sipfrag whose status line does not parse is not a usable outcome. Rejecting
+	// it here extends the short-body guard above rather than letting a malformed
+	// body through as status 0.
+	code, reason, ok := parseSipfragStatus(frag)
+	if !ok {
+		tx.Respond(sip.NewResponseFromRequest(req, sip.StatusBadRequest, "Bad Request", nil))
+		return
+	}
+
 	tx.Respond(sip.NewResponseFromRequest(req, sip.StatusOK, "OK", nil))
 
 	// TODO: We need find better way to store this on refer.
@@ -89,18 +239,13 @@ func dialogHandleReferNotify(d DialogSession, req *sip.Request, tx sip.ServerTra
 	onNot := med.onReferNotify
 	med.mu.Unlock()
 
-	code := func() int {
-		v := strings.TrimPrefix(frag[:11], "SIP/2.0 ")
-		switch v {
-		case "100":
-			return sip.StatusTrying
-		case "200":
-			return sip.StatusOK
-		default:
-			code, _ := strconv.Atoi(v)
-			return code
-		}
-	}()
+	// Only a final sipfrag is a transfer outcome; 1xx is progress. Delivering just
+	// the terminal keeps the waiter's single-slot mailbox from being occupied by a
+	// 100 Trying and dropping the real result.
+	if code >= 200 {
+		id, hasID := parseReferNotifyEventID(req)
+		med.deliverReferResult(id, hasID, referTerminal{status: code, reason: reason})
+	}
 
 	if onNot != nil {
 		onNot(code)

--- a/dialog_session_refer_test.go
+++ b/dialog_session_refer_test.go
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package diago
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emiago/sipgo"
+	"github.com/emiago/sipgo/sip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSipfragStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		frag       string
+		wantStatus int
+		wantReason string
+		wantOK     bool
+	}{
+		{name: "trying", frag: "SIP/2.0 100 Trying", wantStatus: 100, wantReason: "Trying", wantOK: true},
+		{name: "ok", frag: "SIP/2.0 200 OK", wantStatus: 200, wantReason: "OK", wantOK: true},
+		{name: "busy", frag: "SIP/2.0 486 Busy Here", wantStatus: 486, wantReason: "Busy Here", wantOK: true},
+		{name: "only status line is read", frag: "SIP/2.0 486 Busy Here\r\nVia: SIP/2.0/UDP 10.0.0.1", wantStatus: 486, wantReason: "Busy Here", wantOK: true},
+		{name: "no reason phrase", frag: "SIP/2.0 480", wantStatus: 480, wantOK: true},
+		{name: "not a status line", frag: "GARBAGE 486 Busy", wantOK: false},
+		{name: "non numeric code", frag: "SIP/2.0 4x6 Busy", wantOK: false},
+		{name: "code out of range", frag: "SIP/2.0 999 Nope", wantOK: false},
+		{name: "code below range", frag: "SIP/2.0 42 Nope", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, reason, ok := parseSipfragStatus(tt.frag)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantStatus, status)
+			assert.Equal(t, tt.wantReason, reason)
+		})
+	}
+}
+
+func TestParseReferNotifyEventID(t *testing.T) {
+	newReq := func(event string) *sip.Request {
+		req := sip.NewRequest(sip.NOTIFY, sip.Uri{Host: "127.0.0.1"})
+		if event != "" {
+			req.AppendHeader(sip.NewHeader("Event", event))
+		}
+		return req
+	}
+
+	tests := []struct {
+		name      string
+		event     string
+		wantID    uint32
+		wantHasID bool
+	}{
+		{name: "id present", event: "refer;id=42", wantID: 42, wantHasID: true},
+		{name: "id with spacing", event: "refer; id=7", wantID: 7, wantHasID: true},
+		{name: "no id param", event: "refer", wantHasID: false},
+		{name: "no event header", event: "", wantHasID: false},
+		{name: "non numeric id", event: "refer;id=abc", wantHasID: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, hasID := parseReferNotifyEventID(newReq(tt.event))
+			assert.Equal(t, tt.wantHasID, hasID)
+			assert.Equal(t, tt.wantID, id)
+		})
+	}
+}
+
+func TestReferFailureErrorMessageHidesSIPInternals(t *testing.T) {
+	err := &ReferFailureError{Status: 486, Reason: "Busy Here"}
+	assert.Equal(t, "refer transfer failed: 486 Busy Here", err.Error())
+
+	timeout := &ReferFailureError{Status: 0, Reason: "timeout"}
+	assert.Equal(t, "refer transfer failed: timeout", timeout.Error())
+
+	// The error reaches callers that surface it; it must never carry routing state.
+	for _, banned := range []string{"Via", "Contact", "@", "SIP/2.0"} {
+		assert.NotContains(t, err.Error(), banned)
+	}
+}
+
+// TestReferWaiterCorrelation covers the delivery rules of the in-flight REFER
+// waiter without needing a full dialog: an Event id must match the attempt's
+// CSeq, a NOTIFY with no id falls back to the single in-flight attempt, and a
+// finished attempt must not absorb a late NOTIFY.
+func TestReferWaiterCorrelation(t *testing.T) {
+	term := referTerminal{status: 486, reason: "Busy Here"}
+
+	t.Run("no id delivers to single in flight attempt", func(t *testing.T) {
+		d := &DialogMedia{}
+		w := d.beginReferAttempt()
+		d.setReferAttemptCSeq(w, 5)
+
+		d.deliverReferResult(0, false, term)
+		assert.Equal(t, term, <-w.ch)
+	})
+
+	t.Run("matching id delivers", func(t *testing.T) {
+		d := &DialogMedia{}
+		w := d.beginReferAttempt()
+		d.setReferAttemptCSeq(w, 5)
+
+		d.deliverReferResult(5, true, term)
+		assert.Equal(t, term, <-w.ch)
+	})
+
+	t.Run("stale id is dropped", func(t *testing.T) {
+		d := &DialogMedia{}
+		w := d.beginReferAttempt()
+		d.setReferAttemptCSeq(w, 5)
+
+		// A NOTIFY for an earlier REFER on the same dialog must not resolve this one.
+		d.deliverReferResult(4, true, term)
+		assert.Empty(t, w.ch)
+	})
+
+	t.Run("id before cseq known is delivered", func(t *testing.T) {
+		d := &DialogMedia{}
+		w := d.beginReferAttempt()
+
+		// NOTIFY racing ahead of the CSeq being recorded cannot be judged stale.
+		d.deliverReferResult(9, true, term)
+		assert.Equal(t, term, <-w.ch)
+	})
+
+	t.Run("finished attempt does not absorb late notify", func(t *testing.T) {
+		d := &DialogMedia{}
+		w := d.beginReferAttempt()
+		d.endReferAttempt(w)
+
+		d.deliverReferResult(0, false, term)
+		assert.Empty(t, w.ch)
+	})
+
+	t.Run("ended attempt does not clear a newer one", func(t *testing.T) {
+		d := &DialogMedia{}
+		old := d.beginReferAttempt()
+		fresh := d.beginReferAttempt()
+		d.endReferAttempt(old)
+
+		d.deliverReferResult(0, false, term)
+		assert.Equal(t, term, <-fresh.ch)
+	})
+
+	t.Run("delivery never blocks", func(t *testing.T) {
+		d := &DialogMedia{}
+		w := d.beginReferAttempt()
+		d.setReferAttemptCSeq(w, 1)
+
+		// Second delivery must not block once the mailbox is full.
+		d.deliverReferResult(0, false, term)
+		done := make(chan struct{})
+		go func() {
+			d.deliverReferResult(0, false, term)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("deliverReferResult blocked on a full waiter mailbox")
+		}
+	})
+}
+
+// TestIntegrationDialogReferWaitsForOutcome asserts the whole loop: a plain
+// Refer (no OnNotify) reports the real transfer outcome rather than the 202, and
+// a failed transfer surfaces as a typed *ReferFailureError carrying the status.
+func TestIntegrationDialogReferWaitsForOutcome(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// UAS that receives our REFER and drives the referred INVITE.
+	{
+		ua, _ := sipgo.NewUA()
+		defer ua.Close()
+
+		dg := NewDiago(ua, WithTransport(
+			Transport{
+				Transport: "udp",
+				BindHost:  "127.0.0.1",
+				BindPort:  15081,
+				ID:        "udp",
+			},
+		))
+
+		err := dg.ServeBackground(ctx, func(d *DialogServerSession) {
+			d.AnswerOptions(AnswerOptions{
+				OnRefer: func(referDialog *DialogClientSession) error {
+					if err := referDialog.Invite(referDialog.Context(), InviteClientOptions{}); err != nil {
+						return err
+					}
+					if err := referDialog.Ack(ctx); err != nil {
+						return err
+					}
+					return referDialog.Hangup(referDialog.Context())
+				},
+			})
+			<-d.Context().Done()
+		})
+		require.NoError(t, err)
+	}
+
+	// Refer target.
+	{
+		ua, _ := sipgo.NewUA()
+		defer ua.Close()
+
+		dg := NewDiago(ua, WithTransport(
+			Transport{
+				Transport: "udp",
+				BindHost:  "127.0.0.1",
+				BindPort:  15082,
+			},
+		))
+
+		err := dg.ServeBackground(ctx, func(d *DialogServerSession) {
+			switch d.ToUser() {
+			case "busy":
+				d.Respond(sip.StatusBusyHere, "Busy Here", nil)
+				return
+			default:
+				d.Answer()
+			}
+			<-d.Context().Done()
+		})
+		require.NoError(t, err)
+	}
+
+	// UAS that accepts the REFER (so 202 + 100 Trying are sent) but never lets the
+	// referred dialog reach a terminal state, so no terminal sipfrag is ever sent.
+	// Released at test end so the handler goroutine does not linger.
+	stuckRefer := make(chan struct{})
+	defer close(stuckRefer)
+	{
+		ua, _ := sipgo.NewUA()
+		defer ua.Close()
+
+		dg := NewDiago(ua, WithTransport(
+			Transport{
+				Transport: "udp",
+				BindHost:  "127.0.0.1",
+				BindPort:  15083,
+				ID:        "udp",
+			},
+		))
+
+		err := dg.ServeBackground(ctx, func(d *DialogServerSession) {
+			d.AnswerOptions(AnswerOptions{
+				OnRefer: func(referDialog *DialogClientSession) error {
+					<-stuckRefer
+					return nil
+				},
+			})
+			<-d.Context().Done()
+		})
+		require.NoError(t, err)
+	}
+
+	ua, _ := sipgo.NewUA()
+	defer ua.Close()
+
+	dg := NewDiago(ua, WithTransport(
+		Transport{
+			Transport: "udp",
+			BindHost:  "127.0.0.1",
+			BindPort:  15080,
+		},
+	))
+	require.NoError(t, dg.ServeBackground(ctx, nil))
+
+	t.Run("Successful", func(t *testing.T) {
+		d, err := dg.Invite(ctx, sip.Uri{Host: "127.0.0.1", Port: 15081}, InviteOptions{})
+		require.NoError(t, err)
+		defer d.Close()
+		defer d.Hangup(d.Context())
+
+		// Returns only once the terminal sipfrag says the transfer completed.
+		require.NoError(t, d.Refer(d.Context(), sip.Uri{Host: "127.0.0.1", Port: 15082}))
+	})
+
+	t.Run("BusyReturnsTypedFailure", func(t *testing.T) {
+		d, err := dg.Invite(ctx, sip.Uri{Host: "127.0.0.1", Port: 15081}, InviteOptions{})
+		require.NoError(t, err)
+		defer d.Close()
+		defer d.Hangup(d.Context())
+
+		err = d.Refer(d.Context(), sip.Uri{User: "busy", Host: "127.0.0.1", Port: 15082})
+		require.Error(t, err, "refer to a busy target must not report success")
+
+		var referErr *ReferFailureError
+		require.True(t, errors.As(err, &referErr), "want *ReferFailureError, got %T: %v", err, err)
+		assert.Equal(t, sip.StatusBusyHere, referErr.Status)
+		assert.NotContains(t, referErr.Error(), "127.0.0.1")
+	})
+
+	t.Run("NoTerminalNotifyTimesOut", func(t *testing.T) {
+		// Shrink the answer-supervision window so the deadline path is testable.
+		orig := referAnswerDeadline
+		referAnswerDeadline = 200 * time.Millisecond
+		defer func() { referAnswerDeadline = orig }()
+
+		// Talk to the peer that accepts the REFER but never completes it.
+		d, err := dg.Invite(ctx, sip.Uri{Host: "127.0.0.1", Port: 15083}, InviteOptions{})
+		require.NoError(t, err)
+		defer d.Close()
+		defer d.Hangup(d.Context())
+
+		// The REFER is accepted (202) and 100 Trying arrives, but no terminal
+		// sipfrag ever does, so the deadline must decide the outcome.
+		err = d.Refer(d.Context(), sip.Uri{Host: "127.0.0.1", Port: 15082})
+		require.Error(t, err, "a refer with no terminal sipfrag must not report success")
+
+		var referErr *ReferFailureError
+		require.True(t, errors.As(err, &referErr), "want *ReferFailureError, got %T: %v", err, err)
+		assert.Equal(t, 0, referErr.Status, "a timeout carries no SIP status")
+		assert.True(t, strings.Contains(referErr.Reason, "timeout") || strings.Contains(referErr.Reason, "cancelled"))
+	})
+}

--- a/dialog_session_test.go
+++ b/dialog_session_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package diago
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/emiago/sipgo/sip"
+	"github.com/stretchr/testify/require"
+)
+
+// referNotifyDialog is a minimal DialogSession. Only Media and Hangup are
+// reached by dialogHandleReferNotify, the rest stays unimplemented.
+type referNotifyDialog struct {
+	DialogSession
+	media   *DialogMedia
+	hangups int
+}
+
+func (d *referNotifyDialog) Media() *DialogMedia { return d.media }
+
+func (d *referNotifyDialog) Hangup(ctx context.Context) error {
+	d.hangups++
+	return nil
+}
+
+func newReferNotifyRequest(t *testing.T, contentType string, body string) *sip.Request {
+	t.Helper()
+
+	viaParams := sip.NewParams()
+	viaParams.Add("branch", sip.GenerateBranch())
+	fromParams := sip.NewParams()
+	fromParams.Add("tag", "fromtag")
+	toParams := sip.NewParams()
+	toParams.Add("tag", "totag")
+
+	req := sip.NewRequest(sip.NOTIFY, sip.Uri{User: "bob", Host: "127.0.0.1", Port: 5060})
+	req.AppendHeader(&sip.ViaHeader{
+		ProtocolName:    "SIP",
+		ProtocolVersion: "2.0",
+		Transport:       "UDP",
+		Host:            "127.0.0.1",
+		Port:            5060,
+		Params:          viaParams,
+	})
+	req.AppendHeader(&sip.FromHeader{
+		Address: sip.Uri{User: "alice", Host: "127.0.0.1"},
+		Params:  fromParams,
+	})
+	req.AppendHeader(&sip.ToHeader{
+		Address: sip.Uri{User: "bob", Host: "127.0.0.1"},
+		Params:  toParams,
+	})
+	callid := sip.CallIDHeader("refer-notify-test")
+	req.AppendHeader(&callid)
+	req.AppendHeader(&sip.CSeqHeader{SeqNo: 1, MethodName: sip.NOTIFY})
+	req.AppendHeader(sip.NewHeader("Content-Type", contentType))
+	req.SetBody([]byte(body))
+	return req
+}
+
+func newReferNotifyTx(t *testing.T, req *sip.Request) (*sip.ServerTx, *connRecorder) {
+	t.Helper()
+
+	key, err := sip.ServerTxKeyMake(req)
+	require.NoError(t, err)
+
+	conn := NewConnRecorder()
+	tx := sip.NewServerTx(key, req, conn, slog.Default())
+	require.NoError(t, tx.Init())
+	return tx, conn
+}
+
+// TestDialogHandleReferNotifyContentType checks the Content-Type gate on REFER
+// NOTIFY. RFC 3420 Section 5 makes the version parameter of message/sipfrag
+// optional and defaulting to "2.0", so a NOTIFY that omits it must still be
+// accepted and reach the OnNotify callback.
+func TestDialogHandleReferNotifyContentType(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		expectCode  int
+		expectFired bool
+	}{
+		{
+			// Regression: 3CX and other PBXes omit the optional version param.
+			name:        "sipfrag without version param",
+			contentType: "message/sipfrag",
+			expectCode:  sip.StatusOK,
+			expectFired: true,
+		},
+		{
+			name:        "sipfrag with version param",
+			contentType: "message/sipfrag;version=2.0",
+			expectCode:  sip.StatusOK,
+			expectFired: true,
+		},
+		{
+			name:        "unrelated content type is rejected",
+			contentType: "application/sdp",
+			expectCode:  sip.StatusBadRequest,
+			expectFired: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			notified := -1
+			d := &referNotifyDialog{media: &DialogMedia{}}
+			d.media.onReferNotify = func(statusCode int) { notified = statusCode }
+
+			req := newReferNotifyRequest(t, tc.contentType, "SIP/2.0 200 OK")
+			tx, conn := newReferNotifyTx(t, req)
+
+			dialogHandleReferNotify(d, req, tx)
+
+			require.Len(t, conn.msgs, 1)
+			res, ok := conn.msgs[0].(*sip.Response)
+			require.True(t, ok)
+			require.Equal(t, tc.expectCode, res.StatusCode)
+
+			if tc.expectFired {
+				require.Equal(t, sip.StatusOK, notified, "OnNotify should receive the sipfrag status code")
+			} else {
+				require.Equal(t, -1, notified, "OnNotify must not fire on a rejected NOTIFY")
+			}
+			require.Zero(t, d.hangups, "OnNotify handler set, so no implicit hangup")
+		})
+	}
+}
+
+// TestDialogHandleReferNotifyShortBody checks a sipfrag body too short to carry
+// a status line is rejected rather than panicking on the slice.
+func TestDialogHandleReferNotifyShortBody(t *testing.T) {
+	d := &referNotifyDialog{media: &DialogMedia{}}
+	req := newReferNotifyRequest(t, "message/sipfrag", "SIP/2.0")
+	tx, conn := newReferNotifyTx(t, req)
+
+	dialogHandleReferNotify(d, req, tx)
+
+	require.Len(t, conn.msgs, 1)
+	res := conn.msgs[0].(*sip.Response)
+	require.Equal(t, sip.StatusBadRequest, res.StatusCode)
+}


### PR DESCRIPTION
Fixes #162

`Refer` returned as soon as the REFER was accepted with a 202. That only means the peer took the request for processing, so a transfer it later rejects with 486 or 480 still returned nil.

`Refer`, and `ReferOptions` without `OnNotify`, now block after the 202 for the terminal sipfrag NOTIFY and return `*ReferFailureError` carrying the SIP status and reason phrase. A deadline expiry or cancelled parent context returns status 0 with reason `timeout` or `cancelled`.

Correlation matches the Event id against the sent REFER CSeq (RFC 3515 section 2.4.6), falling back to the single in-flight attempt when the peer omits the id — so a stale NOTIFY cannot resolve a later transfer. Only sipfrags with status >= 200 resolve the wait; 1xx still reaches `OnNotify`.

`dialogHandleReferNotify` parses the status line strictly and answers 400 when it does not parse, where it previously passed status 0 to `OnNotify`.

**Existing callers are unaffected.** `ReferOptions` with `OnNotify` set keeps its current behaviour and returns on the 202, so all six existing `Refer` subtests — `Succesfull`, `UnreachableRefer`, `BusyRefer` across the client and server files — pass **unmodified**. No test of yours is deleted or rewritten here.

Three things are opinionated and yours to call: the blocking change on `Refer`, the new 400 path for malformed sipfrags that existing `OnNotify` callers would see, and the 30s deadline, which is an unexported package var that tests can shrink but callers cannot set. #147 lists "should operation block waiting on 200 by default" as your open question — this is one answer to it, happy to take the other shape.

`TestDiagoTransportConfs` fails with and without this change; pre-existing on main.