### PR TITLE
register: call cancel on the unregister context

### DIFF
--- a/diago.go
+++ b/diago.go
@@ -782,7 +782,8 @@ func (dg *Diago) Register(ctx context.Context, recipient sip.Uri, opts RegisterO
 
 	// Unregister
 	defer func() {
-		ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		err := t.Unregister(ctx)
 		if err != nil {
 			dg.log.Error("Failed to unregister", "error", err)


### PR DESCRIPTION
Fixes #164

`diago.go:785` discarded the cancel returned by `context.WithTimeout`. It is the only diagnostic `go vet ./...` reports on the tree, and this makes that output clean.

Being straight about severity: this is not a leak worth chasing. The parent is `context.Background()` and the timer clears after 5 seconds, so nothing outlives the process. The value is a clean vet run, so a real finding later is not lost among a known one.

Two lines.