### PR TITLE
register: refresh from the granted expiry and tolerate a failed refresh

### DIFF
--- a/diago.go
+++ b/diago.go
@@ -821,7 +821,9 @@ func (dg *Diago) Register(ctx context.Context, recipient sip.Uri, opts RegisterO
 			return err
 		}
 
-		t.expiry = retryAfter
+		// Only the refresh cadence, never the recorded grant: an
+		// otherwise live binding must not look already lapsed after a 503.
+		t.setExpiry(retryAfter)
 	}
 }
 

--- a/register_transaction.go
+++ b/register_transaction.go
@@ -9,10 +9,30 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/emiago/sipgo"
 	"github.com/emiago/sipgo/sip"
+)
+
+// registerRefreshRatio is the fraction of the granted expiry at which the
+// binding is refreshed. Refreshing at 3/4 of the grant leaves a quarter of the
+// lifetime for a refresh to fail and be retried before the binding lapses.
+const registerRefreshRatio = 0.75
+
+// registerRetryMin is the shortest refresh interval, so an absent or nonsense
+// grant cannot busy loop the REGISTER path.
+const registerRetryMin = 30 * time.Second
+
+const (
+	// registerRetryBackoffInitial is the wait after the first failed refresh.
+	// Short, because most refresh failures are a blip and the binding is still
+	// good for the remaining quarter of its grant.
+	registerRetryBackoffInitial = 1 * time.Second
+	// registerRetryBackoffMax caps the doubling so a long registrar outage
+	// settles into a steady probe rather than an ever widening one.
+	registerRetryBackoffMax = 5 * time.Minute
 )
 
 type RegisterResponseError struct {
@@ -38,7 +58,10 @@ type RegisterOptions struct {
 
 	// Expiry is for Expire header
 	Expiry time.Duration
-	// Retry interval is interval before next Register is sent
+	// RetryInterval is the interval before the next Register is sent. It can only
+	// bring the refresh forward: an interval longer than what the registrar
+	// granted is clamped to the grant, otherwise the binding lapses before the
+	// refresh fires.
 	RetryInterval time.Duration
 	AllowHeaders  []string
 
@@ -56,7 +79,46 @@ type RegisterTransaction struct {
 	client *sipgo.Client
 	log    *slog.Logger
 
+	// mu guards the registration state below. Diago.Register writes expiry from
+	// its own goroutine while the refresh loop reads it.
+	mu sync.RWMutex
+	// expiry drives the refresh cadence, see calcRetry.
 	expiry time.Duration
+	// grantedExpires and lastRegistered are written only by a successful
+	// REGISTER and describe the binding the registrar actually holds. They are
+	// deliberately kept apart from expiry, which Diago.Register repurposes as a
+	// Retry-After hint on a 503; mixing the two would make an otherwise live
+	// binding look already lapsed.
+	grantedExpires time.Duration
+	lastRegistered time.Time
+	// expiredEmitted latches the escalation so a lapsed binding is reported once
+	// per outage rather than on every subsequent refresh.
+	expiredEmitted bool
+}
+
+// recordGrant stores the expiry the registrar granted on a successful REGISTER
+// and rearms the expired latch, since the binding is demonstrably alive.
+func (t *RegisterTransaction) recordGrant(granted time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.expiry = granted
+	t.grantedExpires = granted
+	t.lastRegistered = time.Now()
+	t.expiredEmitted = false
+}
+
+// setExpiry overrides only the refresh cadence, leaving the recorded grant intact.
+func (t *RegisterTransaction) setExpiry(d time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.expiry = d
+}
+
+// getExpiry reads the current refresh cadence input.
+func (t *RegisterTransaction) getExpiry() time.Duration {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.expiry
 }
 
 func newRegisterTransaction(client *sipgo.Client, recipient sip.Uri, contact sip.ContactHeader, log *slog.Logger, opts RegisterOptions) *RegisterTransaction {
@@ -135,7 +197,7 @@ func (t *RegisterTransaction) register(ctx context.Context) error {
 		req.ReplaceHeader(&contact)
 	}
 
-	if res.StatusCode == sip.StatusUnauthorized || res.StatusCode == sip.StatusProxyAuthRequired {
+	if isDigestChallenge(res) {
 		res, err = client.DoDigestAuth(ctx, req, res, sipgo.DigestAuth{
 			Username: username,
 			Password: password,
@@ -153,66 +215,189 @@ func (t *RegisterTransaction) register(ctx context.Context) error {
 		}
 	}
 
-	// Now update server expiry
-	t.expiry = t.opts.Expiry
-	if h := res.GetHeader("Expires"); h != nil {
-		val, err := strconv.Atoi(h.Value())
-		if err != nil {
-			return fmt.Errorf("failed to parse server Expires value: %w", err)
-		}
-		t.expiry = time.Duration(val) * time.Second
-	}
+	// Record what the registrar granted, which may be far shorter than what was
+	// requested. That grant, not the request, bounds the binding's lifetime.
+	t.recordGrant(grantedExpiry(res, t.opts.Expiry))
 
 	return nil
 }
 
+// isDigestChallenge reports whether a 401/407 is an actual challenge, meaning it
+// carries the matching WWW-Authenticate / Proxy-Authenticate header, rather than
+// a plain rejection.
+//
+// A registrar is free to refuse an account with a challenge-less 401. Running
+// digest against an absent challenge makes sipgo return a bare "No
+// WWW-Authenticate header present" that replaces the final response, so the
+// caller sees neither the status code nor the disposition. Falling through
+// instead yields a RegisterResponseError carrying the real response, which is
+// what a status code classifier needs.
+func isDigestChallenge(res *sip.Response) bool {
+	switch res.StatusCode {
+	case sip.StatusUnauthorized:
+		return res.GetHeader("WWW-Authenticate") != nil
+	case sip.StatusProxyAuthRequired:
+		return res.GetHeader("Proxy-Authenticate") != nil
+	default:
+		return false
+	}
+}
+
+// grantedExpiry resolves a 200 OK's granted lifetime, defaulting to requested.
+//
+// RFC 3261 section 10.3 lets the registrar answer with either a per-Contact
+// expires param or a top level Expires header. The per-Contact param is the
+// binding's own lifetime, so it wins. Only a positive grant counts: expires=0 is
+// a de-registration echo, not a lifetime.
+func grantedExpiry(res *sip.Response, requested time.Duration) time.Duration {
+	if c := res.Contact(); c != nil {
+		if v, ok := c.Params.Get("expires"); ok {
+			if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+				return time.Duration(n) * time.Second
+			}
+		}
+	}
+
+	if h := res.GetHeader("Expires"); h != nil {
+		if n, err := strconv.Atoi(strings.TrimSpace(h.Value())); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+
+	return requested
+}
+
 func (t *RegisterTransaction) QualifyLoop(ctx context.Context) error {
-	// TODO: based on server response Expires header this must be adjusted
-	// Allows caller to adjust
-	expiry := t.expiry
-	retry := t.calcRetry(expiry)
-	return t.reregisterLoop(ctx, retry)
+	return t.reregisterLoop(ctx, t.calcRetry(t.getExpiry()))
+}
+
+// registerRefresher is the half of the refresh loop that talks to the network,
+// split out so the tolerance contract below is testable without a registrar.
+// RegisterTransaction is the only production implementation.
+type registerRefresher interface {
+	// refresh sends one REGISTER refresh.
+	refresh(ctx context.Context) error
+	// cadence reports the wait after a successful refresh, derived from the
+	// expiry the registrar granted.
+	cadence() time.Duration
+	// expired reports whether the binding is provably gone, meaning the last
+	// confirmed registration's granted lifetime has run out. It latches, so a
+	// lapsed binding escalates once per outage.
+	expired() bool
 }
 
 func (t *RegisterTransaction) reregisterLoop(ctx context.Context, retry time.Duration) error {
-	ticker := time.NewTicker(retry)
-	defer ticker.Stop()
+	return registerRefreshLoop(ctx, retry, registerRetryBackoffInitial, registerRetryBackoffMax, t)
+}
 
+// registerRefreshLoop keeps a binding alive, tolerating transient refresh
+// failures instead of surrendering the whole registration to the first one.
+//
+// It used to return on the first failed Qualify, so one 503 or one network blip
+// tore the registration down even though the binding the registrar holds is
+// still valid for the rest of its granted lifetime and the refresh would have
+// succeeded seconds later. The failure arm now backs off exponentially and
+// retries. Escalation is reserved for the case where retrying is provably
+// pointless: expired() reports the granted lifetime has run out, so the
+// registrar has certainly dropped us. Cancellation is a clean shutdown and is
+// surfaced as the context error, never as a failure.
+//
+// The backoff bounds are parameters rather than the constants directly so the
+// tolerance contract is testable at millisecond scale.
+func registerRefreshLoop(ctx context.Context, retry, initialBackoff, maxBackoff time.Duration, r registerRefresher) error {
+	timer := time.NewTimer(retry)
+	defer timer.Stop()
+
+	backoff := initialBackoff
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-ticker.C: // TODO make configurable
+		case <-timer.C:
 		}
-		expiry := t.expiry
-		err := t.Qualify(ctx)
+
+		err := r.refresh(ctx)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		if err != nil {
-			return err
+			if r.expired() {
+				// The binding outlived its grant: no amount of further retrying
+				// brings it back, so hand the error up.
+				return err
+			}
+			timer.Reset(backoff)
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
 		}
 
-		if t.expiry != expiry {
-			// expiry got updated
-			expiry = t.expiry
-			retry = t.calcRetry(expiry)
-
-			t.log.Info("Register expiry changed", "expiry_old", expiry, "expiry_new", t.expiry, "retry", retry)
-			ticker.Reset(retry)
-		}
+		backoff = initialBackoff
+		timer.Reset(r.cadence())
 	}
 }
 
-func (t *RegisterTransaction) calcRetry(expiry time.Duration) time.Duration {
-	// Allow caller to use own interval
-	if t.opts.RetryInterval != 0 {
-		return t.opts.RetryInterval
+// refresh sends one REGISTER refresh, logging a failure that the loop will
+// absorb so a transient outage is still visible.
+func (t *RegisterTransaction) refresh(ctx context.Context) error {
+	expiry := t.getExpiry()
+	if err := t.Qualify(ctx); err != nil {
+		t.log.Warn("Register refresh failed, will retry", "error", err, "expiry", expiry)
+		return err
 	}
 
-	calc := expiry.Seconds() * 0.75
+	if next := t.getExpiry(); next != expiry {
+		t.log.Info("Register expiry changed", "expiry_old", expiry, "expiry_new", next, "retry", t.calcRetry(next))
+	}
+	return nil
+}
+
+// cadence reports the post success wait, recomputed each time so a registrar
+// that shortens the grant mid registration takes effect on the next refresh.
+func (t *RegisterTransaction) cadence() time.Duration {
+	return t.calcRetry(t.getExpiry())
+}
+
+// expired reports whether the last confirmed registration's granted lifetime has
+// run out, latching so one outage escalates once. A transaction that never
+// registered successfully has no binding to lose and never reports expired: the
+// initial Register's own error already covers that case.
+func (t *RegisterTransaction) expired() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.expiredEmitted || t.lastRegistered.IsZero() || t.grantedExpires <= 0 {
+		return false
+	}
+	if !time.Now().After(t.lastRegistered.Add(t.grantedExpires)) {
+		return false
+	}
+	t.expiredEmitted = true
+	return true
+}
+
+// calcRetry derives the refresh cadence from the expiry the registrar granted,
+// so a short grant is refreshed early rather than on a caller chosen wall clock.
+//
+// RetryInterval used to short circuit this outright: whenever it was set it was
+// returned verbatim and the granted expiry was never consulted, so a caller
+// asking for 30m against a registrar granting 120s saw the binding lapse long
+// before the refresh fired. It now only brings the refresh forward.
+func (t *RegisterTransaction) calcRetry(expiry time.Duration) time.Duration {
+	calc := expiry.Seconds() * registerRefreshRatio
 	retry := time.Duration(calc) * time.Second
 
-	// Set to 30 in case retry is not set
-	if retry == 0 {
-		retry = 30 * time.Second
+	// Allow caller to use own interval, but never past the grant.
+	if ri := t.opts.RetryInterval; ri > 0 && (retry <= 0 || ri < retry) {
+		retry = ri
+	}
+
+	// A zero or absent expiry must not yield a zero interval, a busy loop.
+	if retry <= 0 {
+		retry = registerRetryMin
 	}
 
 	return retry
@@ -226,14 +411,25 @@ func (t *RegisterTransaction) Unregister(ctx context.Context) error {
 	req.AppendHeader(sip.NewHeader("Contact", "*"))
 	expires := sip.ExpiresHeader(0)
 	req.AppendHeader(&expires)
-	return t.doRequest(ctx, req)
+	// Deliberately records no grant: the 200 to a de-registration echoes
+	// expires=0, which is the binding going away, not a new lifetime.
+	_, err := t.doRequest(ctx, req)
+	return err
 }
 
+// Qualify refreshes the binding and records the newly granted expiry.
 func (t *RegisterTransaction) Qualify(ctx context.Context) error {
-	return t.doRequest(ctx, t.Origin)
+	res, err := t.doRequest(ctx, t.Origin)
+	if err != nil {
+		return err
+	}
+	// A refresh regrants the binding, so reread the granted expiry every time. A
+	// registrar is free to shorten it mid registration.
+	t.recordGrant(grantedExpiry(res, t.opts.Expiry))
+	return nil
 }
 
-func (t *RegisterTransaction) doRequest(ctx context.Context, req *sip.Request) error {
+func (t *RegisterTransaction) doRequest(ctx context.Context, req *sip.Request) (*sip.Response, error) {
 	// log := p.getLoggerCtx(ctx, "Register")
 	client := t.client
 	username, password := t.opts.Username, t.opts.Password
@@ -242,37 +438,28 @@ func (t *RegisterTransaction) doRequest(ctx context.Context, req *sip.Request) e
 	req.RemoveHeader("Via")
 	res, err := client.Do(ctx, req, sipgo.ClientRequestRegisterBuild)
 	if err != nil {
-		return fmt.Errorf("fail to get response req=%q : %w", req.StartLine(), err)
+		return nil, fmt.Errorf("fail to get response req=%q : %w", req.StartLine(), err)
 	}
 
-	if res.StatusCode == sip.StatusUnauthorized || res.StatusCode == sip.StatusProxyAuthRequired {
+	if isDigestChallenge(res) {
 		res, err = client.DoDigestAuth(ctx, req, res, sipgo.DigestAuth{
 			Username: username,
 			Password: password,
 		})
 		if err != nil {
-			return fmt.Errorf("fail to get response req=%q : %w", req.StartLine(), err)
+			return nil, fmt.Errorf("fail to get response req=%q : %w", req.StartLine(), err)
 		}
 	}
 
 	if res.StatusCode != 200 {
-		return &RegisterResponseError{
+		return nil, &RegisterResponseError{
 			RegisterReq: req,
 			RegisterRes: res,
 			Msg:         res.StartLine(),
 		}
 	}
 
-	// Check is expirese changed
-	if h := res.GetHeader("Expires"); h != nil {
-		val, err := strconv.Atoi(h.Value())
-		if err != nil {
-			return fmt.Errorf("Failed to parse server Expires value: %w", err)
-		}
-		t.expiry = time.Duration(val) * time.Second
-	}
-
-	return nil
+	return res, nil
 }
 
 func getResponse(ctx context.Context, tx sip.ClientTransaction) (*sip.Response, error) {

--- a/register_transaction_test.go
+++ b/register_transaction_test.go
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package diago
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/emiago/sipgo/sip"
+)
+
+// A registrar may grant a shorter lifetime than requested, and the common way is
+// a per-Contact expires param rather than a top level Expires header. Reading
+// only the top level header meant a 120s grant was recorded as the requested 1h,
+// so the binding lapsed long before the refresh fired.
+func TestGrantedExpiry(t *testing.T) {
+	const requested = time.Hour
+
+	for _, tc := range []struct {
+		name    string
+		headers []sip.Header
+		want    time.Duration
+	}{
+		{
+			name:    "contact expires param",
+			headers: []sip.Header{sip.NewHeader("Contact", "<sip:alice@10.0.0.5:5060>;expires=120")},
+			want:    120 * time.Second,
+		},
+		{
+			name:    "top level Expires header",
+			headers: []sip.Header{sip.NewHeader("Expires", "300")},
+			want:    300 * time.Second,
+		},
+		{
+			// The per-Contact param is the binding's own lifetime, so it wins.
+			name: "contact param beats top level Expires",
+			headers: []sip.Header{
+				sip.NewHeader("Contact", "<sip:alice@10.0.0.5:5060>;expires=120"),
+				sip.NewHeader("Expires", "3600"),
+			},
+			want: 120 * time.Second,
+		},
+		{
+			// A registrar that grants silently: the requested value stands.
+			name: "no header falls back to requested",
+			want: requested,
+		},
+		{
+			// expires=0 is a de-registration echo, not a grant. A zero lifetime
+			// would otherwise pin calcRetry to its floor forever.
+			name:    "non positive grant ignored",
+			headers: []sip.Header{sip.NewHeader("Contact", "<sip:alice@10.0.0.5:5060>;expires=0")},
+			want:    requested,
+		},
+		{
+			// Used to be a hard error that replaced the response.
+			name:    "unparseable grant falls back to requested",
+			headers: []sip.Header{sip.NewHeader("Expires", "soon")},
+			want:    requested,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := sip.NewResponse(sip.StatusOK, "OK")
+			for _, h := range tc.headers {
+				res.AppendHeader(h)
+			}
+			if got := grantedExpiry(res, requested); got != tc.want {
+				t.Errorf("grantedExpiry() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The refresh cadence must come from what the registrar granted. calcRetry used
+// to return RetryInterval verbatim whenever it was set, so the grant was never
+// consulted and a 120s grant still refreshed on the caller's 30m clock.
+func TestCalcRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		retryInterval time.Duration
+		expiry        time.Duration
+		want          time.Duration
+	}{
+		{name: "ratio of the grant", expiry: 120 * time.Second, want: 90 * time.Second},
+		{name: "ratio of a long grant", expiry: time.Hour, want: 45 * time.Minute},
+		{
+			// The whole point: 30m against a 120s grant used to win outright and
+			// the binding lapsed 28 minutes before the refresh.
+			name:          "RetryInterval past the grant is clamped",
+			retryInterval: 30 * time.Minute,
+			expiry:        120 * time.Second,
+			want:          90 * time.Second,
+		},
+		{
+			name:          "RetryInterval inside the grant still honoured",
+			retryInterval: 10 * time.Minute,
+			expiry:        time.Hour,
+			want:          10 * time.Minute,
+		},
+		{
+			// A zero interval would busy loop the REGISTER path.
+			name:   "absent expiry floors",
+			expiry: 0,
+			want:   registerRetryMin,
+		},
+		{
+			name:          "absent expiry with a caller interval",
+			retryInterval: 5 * time.Second,
+			expiry:        0,
+			want:          5 * time.Second,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &RegisterTransaction{opts: RegisterOptions{RetryInterval: tc.retryInterval}}
+			if got := tr.calcRetry(tc.expiry); got != tc.want {
+				t.Errorf("calcRetry(%v) = %v, want %v", tc.expiry, got, tc.want)
+			}
+		})
+	}
+}
+
+// A registrar is free to refuse an account with a challenge-less 401. Running
+// digest against an absent challenge returns a bare "No WWW-Authenticate header
+// present" that replaces the real response, hiding the status code from the
+// caller's classifier.
+func TestIsDigestChallenge(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		header string
+		want   bool
+	}{
+		{name: "401 with challenge", status: sip.StatusUnauthorized, header: "WWW-Authenticate", want: true},
+		{name: "401 without challenge", status: sip.StatusUnauthorized, want: false},
+		{name: "407 with challenge", status: sip.StatusProxyAuthRequired, header: "Proxy-Authenticate", want: true},
+		{name: "407 without challenge", status: sip.StatusProxyAuthRequired, want: false},
+		{name: "401 carrying only the proxy challenge", status: sip.StatusUnauthorized, header: "Proxy-Authenticate", want: false},
+		{name: "200", status: sip.StatusOK, want: false},
+		{name: "403", status: sip.StatusForbidden, header: "WWW-Authenticate", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := sip.NewResponse(tc.status, "")
+			if tc.header != "" {
+				res.AppendHeader(sip.NewHeader(tc.header, `Digest realm="test", nonce="abc"`))
+			}
+			if got := isDigestChallenge(res); got != tc.want {
+				t.Errorf("isDigestChallenge(%d) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+var errRegisterRefresh = errors.New("register refresh failed")
+
+// The production constants are seconds and minutes, so the loop takes its bounds
+// as parameters and the tests drive it at millisecond scale.
+const (
+	testBackoffInitial = 10 * time.Millisecond
+	testBackoffMax     = 80 * time.Millisecond
+)
+
+// fakeRefresher drives registerRefreshLoop without a registrar.
+type fakeRefresher struct {
+	results    []error // one per refresh call, in order
+	calls      int
+	at         []time.Time // wall time of each refresh call, for gap assertions
+	isExpired  bool
+	expiredAt  int // call index (1 based) at/after which expired() flips
+	cadenceDur time.Duration
+	stop       context.CancelFunc
+	stopAfter  int // cancel ctx once this many refreshes have run (0 = never)
+}
+
+func (f *fakeRefresher) refresh(context.Context) error {
+	var err error
+	if f.calls < len(f.results) {
+		err = f.results[f.calls]
+	}
+	f.calls++
+	f.at = append(f.at, time.Now())
+	if f.expiredAt > 0 && f.calls >= f.expiredAt {
+		f.isExpired = true
+	}
+	if f.stopAfter > 0 && f.calls >= f.stopAfter && f.stop != nil {
+		f.stop()
+	}
+	return err
+}
+
+func (f *fakeRefresher) cadence() time.Duration { return f.cadenceDur }
+func (f *fakeRefresher) expired() bool          { return f.isExpired }
+
+// gap reports the wait the loop took before refresh call n (1 based).
+func (f *fakeRefresher) gap(n int) time.Duration { return f.at[n-1].Sub(f.at[n-2]) }
+
+// The loop used to return the first refresh error, tearing the registration down
+// on one 503 or one network blip while the registrar still held a perfectly
+// valid binding. A failure whose binding has not lapsed must be retried.
+func TestRegisterRefreshLoopBacksOffInsteadOfTearingDown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := &fakeRefresher{
+		// Four consecutive failures, none of which lapse the binding.
+		results:    []error{errRegisterRefresh, errRegisterRefresh, errRegisterRefresh, errRegisterRefresh},
+		cadenceDur: time.Millisecond,
+		stop:       cancel,
+		stopAfter:  4,
+	}
+
+	err := registerRefreshLoop(ctx, time.Millisecond, testBackoffInitial, testBackoffMax, f)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("loop = %v, want context.Canceled: a failure that has not lapsed the binding must be retried, never escalated", err)
+	}
+	if f.calls != 4 {
+		t.Fatalf("refresh called %d times, want 4, it must keep retrying through failures", f.calls)
+	}
+
+	// The retries must actually back off: 10ms, 20ms, 40ms. Asserted as a lower
+	// bound only, since a loaded CI box can stretch a timer but never shrink it.
+	for n, min := range map[int]time.Duration{2: testBackoffInitial, 3: 2 * testBackoffInitial, 4: 4 * testBackoffInitial} {
+		if got := f.gap(n); got < min {
+			t.Errorf("wait before refresh #%d = %v, want >= %v, backoff must double", n, got, min)
+		}
+	}
+}
+
+// The other half: a binding whose granted lifetime has run out is genuinely
+// gone, retrying is pointless, and the error must reach the caller.
+func TestRegisterRefreshLoopEscalatesOnlyWhenProvablyDead(t *testing.T) {
+	f := &fakeRefresher{
+		results:    []error{errRegisterRefresh, errRegisterRefresh, errRegisterRefresh},
+		cadenceDur: time.Millisecond,
+		expiredAt:  3, // binding lapses only by the 3rd failure
+	}
+
+	err := registerRefreshLoop(context.Background(), time.Millisecond, testBackoffInitial, testBackoffMax, f)
+
+	if !errors.Is(err, errRegisterRefresh) {
+		t.Fatalf("loop = %v, want errRegisterRefresh once the grant has lapsed", err)
+	}
+	if f.calls != 3 {
+		t.Fatalf("refresh called %d times, want exactly 3, it must escalate on the first failure after the grant lapsed, not before", f.calls)
+	}
+}
+
+// A recovered refresh must drop out of backoff and return to the granted expiry
+// cadence. Without the reset, a binding that had a rough hour keeps refreshing
+// at the 5m cap even after the registrar returns, and a registrar granting less
+// than 5m would then lapse on every cycle.
+func TestRegisterRefreshLoopSuccessResetsBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := &fakeRefresher{
+		// fail, fail, fail (backoff now at 80ms), OK, fail
+		results:    []error{errRegisterRefresh, errRegisterRefresh, errRegisterRefresh, nil, errRegisterRefresh},
+		cadenceDur: time.Millisecond,
+		stop:       cancel,
+		stopAfter:  5,
+	}
+
+	err := registerRefreshLoop(ctx, time.Millisecond, testBackoffInitial, testBackoffMax, f)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("loop = %v, want context.Canceled", err)
+	}
+	if f.calls != 5 {
+		t.Fatalf("refresh called %d times, want 5", f.calls)
+	}
+
+	// #5 follows the OK and so must wait only the 1ms cadence, not the 80ms
+	// backoff step it would otherwise have taken.
+	if got := f.gap(5); got >= 4*testBackoffInitial {
+		t.Errorf("wait before the post recovery refresh = %v, want well under %v: a successful refresh must reset the backoff to the granted expiry cadence", got, 4*testBackoffInitial)
+	}
+}
+
+// A clean shutdown is surfaced as the context error, never mistaken for a dead
+// binding.
+func TestRegisterRefreshLoopExitsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	f := &fakeRefresher{cadenceDur: time.Millisecond}
+
+	err := registerRefreshLoop(ctx, time.Hour, testBackoffInitial, testBackoffMax, f)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("loop = %v, want context.Canceled", err)
+	}
+	if f.calls != 0 {
+		t.Fatalf("refresh called %d times, want 0 on an already cancelled context", f.calls)
+	}
+}
+
+// expired() is the contract the loop's escalation arm rests on.
+func TestExpired(t *testing.T) {
+	t.Run("never registered", func(t *testing.T) {
+		tr := &RegisterTransaction{}
+		if tr.expired() {
+			t.Error("expired() = true with no successful REGISTER; there is no binding to lose, and the initial Register's own error already covers that case")
+		}
+	})
+
+	t.Run("still inside the grant", func(t *testing.T) {
+		tr := &RegisterTransaction{}
+		tr.recordGrant(time.Hour)
+		if tr.expired() {
+			t.Error("expired() = true 0s into a 1h grant; a refresh failure here must back off, not escalate")
+		}
+	})
+
+	t.Run("past the grant, latching", func(t *testing.T) {
+		tr := &RegisterTransaction{}
+		tr.recordGrant(time.Minute)
+		tr.mu.Lock()
+		tr.lastRegistered = time.Now().Add(-2 * time.Minute)
+		tr.mu.Unlock()
+
+		if !tr.expired() {
+			t.Fatal("expired() = false past the grant, want true")
+		}
+		if tr.expired() {
+			t.Error("expired() = true twice; it must latch so one outage escalates once")
+		}
+	})
+
+	t.Run("a successful refresh rearms the latch", func(t *testing.T) {
+		tr := &RegisterTransaction{}
+		tr.recordGrant(time.Minute)
+		tr.mu.Lock()
+		tr.lastRegistered = time.Now().Add(-2 * time.Minute)
+		tr.mu.Unlock()
+
+		if !tr.expired() {
+			t.Fatal("expired() = false past the grant, want true")
+		}
+
+		tr.recordGrant(time.Minute) // registrar came back
+		tr.mu.Lock()
+		tr.lastRegistered = time.Now().Add(-2 * time.Minute)
+		tr.mu.Unlock()
+
+		if !tr.expired() {
+			t.Error("expired() = false after a successful refresh rearmed the latch; a second, later outage must be able to escalate again")
+		}
+	})
+}
+
+// Diago.Register writes a Retry-After into the refresh cadence on a 503. That
+// must not disturb the recorded grant, or an otherwise live binding looks
+// already lapsed and trips the escalation arm.
+func TestSetExpiryLeavesGrantIntact(t *testing.T) {
+	tr := &RegisterTransaction{}
+	tr.recordGrant(time.Hour)
+
+	tr.setExpiry(5 * time.Second)
+
+	if got := tr.getExpiry(); got != 5*time.Second {
+		t.Errorf("getExpiry() = %v, want the 5s Retry-After", got)
+	}
+	if tr.expired() {
+		t.Error("expired() = true after a Retry-After shortened only the cadence; the 1h grant is still live")
+	}
+}


### PR DESCRIPTION
Fixes #166

**The granted expiry was never read.** `QualifyLoop` refreshed on `t.expiry` — the value we requested — and carried the `TODO` saying so. A registrar granting 120s against a requested hour saw the binding lapse before the refresh fired. The grant arrives in the per-Contact `expires` param as often as the top-level `Expires` header (RFC 3261 10.3); both are now read.

**`calcRetry` returned `RetryInterval` verbatim when set**, so the 0.75 ratio never ran for any caller who set it. `RetryInterval` is kept but can now only bring the refresh *forward*, never past the derived point, with a 30s floor.

**`reregisterLoop` returned on the first failed refresh.** One 503 tore the registration down while the registrar still held a valid binding. A failure now backs off exponentially (1s doubling to a 5min cap) and escalates only once the granted lifetime has provably run out, latching so one outage escalates once.

Also on that path: the registration state goes behind an `RWMutex`, since `Diago.Register` writes the expiry from its own goroutine while the refresh loop reads it — `go test -race` covers it. An unparseable or non-positive `Expires` falls back to the requested expiry rather than returning an error, and digest auth is gated on the challenge header being present.

**No new exported API.** Against current behaviour the tolerance tests fail with the loop returning on first error.