### PR TITLE
dialog: negotiate RFC 4028 session timers on the UAS answer path

### DIFF
--- a/diago.go
+++ b/diago.go
@@ -33,6 +33,10 @@ type Diago struct {
 	auth      sipgo.DigestAuth
 	mediaConf MediaConfig
 
+	// sessionTimers is the RFC 4028 session-timer policy stamped onto each dialog
+	// at construction.
+	sessionTimers SessionTimerPolicy
+
 	log *slog.Logger
 
 	cache            DialogCachePool
@@ -164,6 +168,16 @@ func WithMediaConfig(conf MediaConfig) DiagoOption {
 	}
 }
 
+// WithSessionTimers sets the RFC 4028 session-timer policy stamped onto each
+// dialog at construction. The policy drives negotiation, the refresh loop and
+// the peer-refresh watchdog. Without this option session timers stay disabled
+// and diago neither advertises nor enforces them.
+func WithSessionTimers(p SessionTimerPolicy) DiagoOption {
+	return func(dg *Diago) {
+		dg.sessionTimers = p
+	}
+}
+
 // WithServer allows providing custom server handle. Consider still it needs to use same UA as diago
 func WithServer(srv *sipgo.Server) DiagoOption {
 	return func(dg *Diago) {
@@ -288,6 +302,7 @@ func NewDiago(ua *sipgo.UserAgent, opts ...DiagoOption) *Diago {
 				externalIP: tran.MediaExternalIP,
 				dtlsConf:   tran.MediaDTLSConf,
 			},
+			sessionTimers: dg.sessionTimers,
 		}
 
 		defer closeAndLog(dWrap, "closing dialog server returned error")

--- a/dialog_server_session.go
+++ b/dialog_server_session.go
@@ -10,6 +10,7 @@ import (
 	"math/rand/v2"
 	mrand "math/rand/v2"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -31,7 +32,21 @@ type DialogServerSession struct {
 	onReferDialog OnReferDialogFunc
 
 	mediaConf MediaConfig
-	closed    atomic.Uint32
+
+	// sessionTimers is the RFC 4028 policy stamped from dg.sessionTimers at
+	// construction. It is consumed by the answer path.
+	sessionTimers SessionTimerPolicy
+	// timerAnswer holds the negotiated timer outcome for this answer, nil until a
+	// timer-supporting peer is negotiated. Guarded by d.mu.
+	timerAnswer *timerAnswer
+	// timerOnce guards the refresh loop and watchdog launch so a re-answer or an
+	// inbound refresh can never spawn a second goroutine.
+	timerOnce sync.Once
+	// watchdog is the armed peer-refresh watchdog, set when the peer is the
+	// refresher and reset on an inbound refresh re-INVITE. Guarded by d.mu.
+	watchdog *peerRefreshWatchdog
+
+	closed atomic.Uint32
 }
 
 func (d *DialogServerSession) Id() string {
@@ -122,15 +137,156 @@ func (d *DialogServerSession) RemoteContact() *sip.ContactHeader {
 	return d.InviteRequest.Contact()
 }
 
+// statusSessionIntervalTooSmall is the RFC 4028 §6 rejection for an offered
+// Session-Expires below the Min-SE floor. sipgo carries no constant for it.
+const statusSessionIntervalTooSmall = 422
+
+// errSessionIntervalTooSmall aborts the answer when the offered Session-Expires
+// is below the Min-SE floor. A 422 has already been sent to the peer.
+var errSessionIntervalTooSmall = errors.New("session interval too small")
+
+// timerAnswer is the negotiated RFC 4028 outcome for a single answer: the
+// headers to append to the 200 OK and the parameters for the refresh loop or the
+// peer-refresh watchdog. It is computed before RespondSDP and consumed once the
+// 200 OK is sent.
+type timerAnswer struct {
+	headers     []sip.Header
+	interval    time.Duration
+	weRefresh   bool
+	armWatchdog bool
+	expiry      time.Duration
+}
+
+// buildTimerAnswer is the pure UAS answer-path decision for RFC 4028 session
+// timers. Given the offered INVITE and our policy it returns the headers to add
+// to the 200 OK (or the Min-SE header for a 422) and the response status. It
+// keeps every SIP-transaction dependency out so the decision is unit testable
+// without a PBX.
+//
+//   - timers disabled, or the peer offered no Session-Expires (timer-unaware) →
+//     no headers, status 200, nil answer: a graceful no-op, never a rejection.
+//   - offered Session-Expires below the floor → status 422 plus Min-SE, nil
+//     answer, so no media, no loop and no watchdog.
+//   - otherwise → Session-Expires with the honored refresher plus Supported:
+//     timer (never Require: timer), and an answer that either refreshes or arms
+//     the watchdog.
+func buildTimerAnswer(invite *sip.Request, policy SessionTimerPolicy) (ta *timerAnswer, hdrs []sip.Header, status int) {
+	if !policy.Enabled {
+		return nil, nil, sip.StatusOK
+	}
+
+	offer, ok := parseSessionTimerOffer(invite)
+	if !ok {
+		// Timer-unaware peer: answer normally with no timer headers, start nothing.
+		return nil, nil, sip.StatusOK
+	}
+
+	dec := negotiate(offer.SE, offer.MinSE, offer.Refresher, policy, refresherUAS)
+
+	if dec.BelowFloor {
+		// RFC 4028 §6: reject below-floor and echo our Min-SE, establishing nothing.
+		return nil, []sip.Header{sip.NewHeader("Min-SE", secondsOf(dec.Negotiated))}, statusSessionIntervalTooSmall
+	}
+
+	seValue := secondsOf(dec.Negotiated)
+	if dec.Refresher != "" {
+		seValue += ";refresher=" + dec.Refresher
+	}
+	hdrs = []sip.Header{
+		sip.NewHeader("Session-Expires", seValue),
+		sip.NewHeader("Supported", "timer"),
+	}
+	// We refresh when we are the elected refresher, otherwise the peer refreshes
+	// and we arm a watchdog to bound a peer that stops refreshing.
+	return &timerAnswer{
+		headers:     hdrs,
+		interval:    dec.Interval,
+		weRefresh:   dec.WeRefresh,
+		armWatchdog: !dec.WeRefresh,
+		expiry:      dec.Negotiated,
+	}, hdrs, sip.StatusOK
+}
+
+// prepareSessionTimers negotiates RFC 4028 session timers for the answer. On a
+// below-floor offer it sends 422 with Min-SE and returns
+// errSessionIntervalTooSmall so the caller aborts before any media, loop or
+// watchdog. Otherwise it stashes the timer headers, which RespondSDP appends to
+// the 200 OK, along with the launch parameters. A timer-unaware peer or a
+// disabled policy leaves d.timerAnswer nil, a graceful no-op.
+func (d *DialogServerSession) prepareSessionTimers() error {
+	ta, hdrs, status := buildTimerAnswer(d.InviteRequest, d.sessionTimers)
+	if status == statusSessionIntervalTooSmall {
+		if err := d.Respond(statusSessionIntervalTooSmall, "Session Interval Too Small", nil, hdrs...); err != nil {
+			return err
+		}
+		return errSessionIntervalTooSmall
+	}
+	if ta == nil {
+		return nil
+	}
+	d.mu.Lock()
+	d.timerAnswer = ta
+	d.mu.Unlock()
+	return nil
+}
+
+// launchSessionTimers starts the RFC 4028 timer for this dialog exactly once.
+// When we are the elected refresher it runs the refresh loop, re-INVITEing at
+// half the negotiated interval. Otherwise the peer refreshes and it arms a
+// watchdog that hangs up on a missed refresh. Both run on d.Context() so dialog
+// teardown cancels them, and the grace comes from the policy via watchdogGrace.
+func (d *DialogServerSession) launchSessionTimers(ta *timerAnswer) {
+	d.timerOnce.Do(func() {
+		switch {
+		case ta.weRefresh:
+			// Fire and forget: the loop's lifecycle is the dialog context, so it exits
+			// on Close or Bye. Its escalation error is not propagated here because
+			// there is no per-dialog error channel on the answer path, and a stalled
+			// refresh is independently bounded by the peer's own session timer.
+			go sessionRefreshLoop(d.Context(), ta.interval, d.ReInvite) //nolint:errcheck // see comment above
+		case ta.armWatchdog:
+			w := armPeerRefreshWatchdog(d.Context(), ta.expiry, watchdogGrace(d.sessionTimers), d.Hangup)
+			d.mu.Lock()
+			d.watchdog = w
+			d.mu.Unlock()
+		}
+	})
+}
+
 func (d *DialogServerSession) RespondSDP(body []byte) error {
 	headers := []sip.Header{sip.NewHeader("Content-Type", "application/sdp")}
-	return d.DialogServerSession.Respond(200, "OK", body, headers...)
+
+	d.mu.Lock()
+	ta := d.timerAnswer
+	d.mu.Unlock()
+	if ta != nil {
+		headers = append(headers, ta.headers...)
+	}
+
+	if err := d.DialogServerSession.Respond(200, "OK", body, headers...); err != nil {
+		return err
+	}
+
+	// The 200 OK established the session, so start the refresh loop or arm the
+	// peer-refresh watchdog now, exactly once and on the dialog context so
+	// teardown cancels it.
+	if ta != nil {
+		d.launchSessionTimers(ta)
+	}
+	return nil
 }
 
 // Answer creates media session and answers
 // After this new AudioReader and AudioWriter are created for audio manipulation
 // NOTE: Not final API
 func (d *DialogServerSession) Answer() error {
+	// RFC 4028: negotiate session timers before the 200 OK. A below-floor offer is
+	// rejected here with 422 and aborts the answer. The timer headers are stashed
+	// for RespondSDP, which launches the loop or watchdog once the 200 OK is sent.
+	if err := d.prepareSessionTimers(); err != nil {
+		return err
+	}
+
 	// Media Exists as early
 	if d.mediaSession != nil {
 		// This will now block until ACK received with 64*T1 as max.
@@ -176,6 +332,11 @@ func (d *DialogServerSession) AnswerOptions(opt AnswerOptions) error {
 	d.onReferDialog = opt.OnRefer
 	d.onMediaUpdate = opt.OnMediaUpdate
 	d.mu.Unlock()
+
+	// RFC 4028: mirror Answer and negotiate session timers before the 200 OK.
+	if err := d.prepareSessionTimers(); err != nil {
+		return err
+	}
 
 	// If media exists as early, only respond 200
 	if d.mediaSession != nil {
@@ -545,7 +706,32 @@ func (d *DialogServerSession) handleReInvite(req *sip.Request, tx sip.ServerTran
 		return tx.Respond(sip.NewResponseFromRequest(req, sip.StatusBadRequest, err.Error(), nil))
 	}
 
+	// RFC 4028: an inbound refresh re-INVITE resets the active timer. When the
+	// peer is the refresher its watchdog is rearmed. When we refresh, the loop's
+	// ticker self-rearms each tick, so no reset is needed. A plain media-update
+	// re-INVITE carries no Session-Expires and is a no-op here.
+	d.resetSessionTimerOnRefresh(req)
+
 	return d.handleMediaUpdate(req, tx, d.InviteResponse.Contact())
+}
+
+// resetSessionTimerOnRefresh rearms the peer-refresh watchdog when req is an RFC
+// 4028 refresh re-INVITE. It is a no-op when timers are disabled, when the
+// request carries no Session-Expires, or when we are the refresher and therefore
+// have no watchdog armed.
+func (d *DialogServerSession) resetSessionTimerOnRefresh(req *sip.Request) {
+	if !d.sessionTimers.Enabled {
+		return
+	}
+	if _, ok := parseSessionTimerOffer(req); !ok {
+		return
+	}
+	d.mu.Lock()
+	w := d.watchdog
+	d.mu.Unlock()
+	if w != nil {
+		w.Reset()
+	}
 }
 
 func (d *DialogServerSession) readSIPInfoDTMF(req *sip.Request, tx sip.ServerTransaction) error {

--- a/session_timers.go
+++ b/session_timers.go
@@ -61,6 +61,11 @@ type SessionTimerPolicy struct {
 	// defaultMinSE. The effective floor is max(MinSE, the peer's offered Min-SE).
 	MinSE time.Duration
 
+	// PreferUASRefresher is a tiebreaker applied only when the peer omits a
+	// refresher: true elects "uas", false stays neutral. When the peer offers a
+	// refresher it is always honored and this never overrides it.
+	PreferUASRefresher bool
+
 	// WatchdogGrace is the tolerance added to the negotiated interval before the
 	// peer-refresh watchdog hangs up on a missed refresh. Zero falls back to
 	// defaultWatchdogGrace.
@@ -102,9 +107,9 @@ func watchdogGrace(policy SessionTimerPolicy) time.Duration {
 // negotiate is a pure, role-agnostic RFC 4028 session-timer negotiation. Given a
 // peer's offered Session-Expires, Min-SE and refresher plus our policy it floors
 // the interval by Min-SE, falls back to the advertise-fallback when nothing is
-// offered, halves for the refresh cadence, honors the peer's refresher and
-// elects ourRole when the peer omits one, and flags a below-floor offer for a
-// 422 reply. ourRole only decides WeRefresh, so the same
+// offered, halves for the refresh cadence, honors the peer's refresher (using
+// PreferUASRefresher only as a tiebreaker when the peer omits one) and flags a
+// below-floor offer for a 422 reply. ourRole only decides WeRefresh, so the same
 // function serves the UAS answer path and a future UAC client path unchanged.
 //
 // All inputs are bounded uint32 deltas, so the duration arithmetic cannot
@@ -155,14 +160,11 @@ func negotiate(offeredSE *uint32, offeredMinSE *uint32, offeredRefresher string,
 		interval = minRefreshInterval
 	}
 
-	// Honor the peer's offered refresher, and elect ourselves when it omits one.
-	// RFC 4028 section 9 requires the 2xx to name a refresher, and leaving it
-	// unset would arm the watchdog against a peer that was never asked to
-	// refresh -- it would then hang up at the interval plus grace on a healthy
-	// session.
+	// Honor the peer's offered refresher. Only tiebreak with PreferUASRefresher
+	// when the peer omitted one; false stays neutral and never forces "uas".
 	refresher := offeredRefresher
-	if refresher == "" {
-		refresher = ourRole
+	if refresher == "" && policy.PreferUASRefresher {
+		refresher = refresherUAS
 	}
 
 	return sessionTimerDecision{
@@ -184,13 +186,13 @@ type sessionTimerOffer struct {
 // parseSessionTimerOffer reads Session-Expires and Min-SE off a request. sipgo
 // carries no typed accessors for these headers, so they are read generically and
 // parsed here. A malformed or out-of-range value is treated as absent rather
-// than as an error: RFC 4028 §7.4 has the receiver ignore what it cannot parse,
-// and a timer header is never worth failing an otherwise valid INVITE over.
+// than as an error: a timer header is never worth failing an otherwise valid
+// INVITE over.
 // ok is false when the peer sent no Session-Expires at all (timer-unaware).
 func parseSessionTimerOffer(req *sip.Request) (offer sessionTimerOffer, ok bool) {
 	h := req.GetHeader("Session-Expires")
 	if h == nil {
-		// Compact form of Session-Expires per RFC 4028 §7.1.
+		// Compact form of Session-Expires per RFC 4028 §4.
 		h = req.GetHeader("x")
 	}
 	if h == nil {

--- a/session_timers.go
+++ b/session_timers.go
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package diago
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/emiago/sipgo/sip"
+)
+
+// RFC 4028 session-timer policy defaults.
+const (
+	// defaultSessionExpires is the session interval we advertise as a fallback
+	// only when a timer-supporting peer offers no Session-Expires of its own.
+	// SessionTimerPolicy.DefaultSE overrides it. It is never a value imposed on
+	// a peer that offered one.
+	defaultSessionExpires = 1800 * time.Second
+
+	// defaultMinSE is the minimum acceptable session interval, the RFC 4028 §4
+	// default of 90 seconds. An offered Session-Expires below this is reported
+	// as below-floor so the answer path can reject with 422 and a Min-SE header.
+	defaultMinSE = 90 * time.Second
+
+	// defaultWatchdogGrace is the tolerance added to the negotiated interval
+	// before the peer-refresh watchdog hangs up on a missed refresh. Used when
+	// SessionTimerPolicy.WatchdogGrace is zero.
+	defaultWatchdogGrace = 5 * time.Second
+
+	// minRefreshInterval clamps the refresh cadence so a tiny offered
+	// Session-Expires can never drive a sub-floor re-INVITE storm.
+	minRefreshInterval = defaultMinSE / 2
+)
+
+// Refresher tokens as carried in the RFC 4028 refresher parameter.
+const (
+	refresherUAS = "uas"
+	refresherUAC = "uac"
+)
+
+// SessionTimerPolicy is the RFC 4028 session-timer policy. It is stamped onto
+// each dialog at construction via WithSessionTimers and drives negotiation, the
+// refresh loop and the peer-refresh watchdog. The zero value is disabled and is
+// safe to use.
+type SessionTimerPolicy struct {
+	// Enabled turns session-timer advertisement and negotiation on.
+	Enabled bool
+
+	// DefaultSE is the advertise-fallback session interval, used only when we
+	// advertise to a timer-supporting peer that offered no Session-Expires. Zero
+	// falls back to defaultSessionExpires. It is never imposed on a peer's own
+	// offer.
+	DefaultSE time.Duration
+
+	// MinSE is our floor for an acceptable session interval. Zero falls back to
+	// defaultMinSE. The effective floor is max(MinSE, the peer's offered Min-SE).
+	MinSE time.Duration
+
+	// WatchdogGrace is the tolerance added to the negotiated interval before the
+	// peer-refresh watchdog hangs up on a missed refresh. Zero falls back to
+	// defaultWatchdogGrace.
+	WatchdogGrace time.Duration
+}
+
+// sessionTimerDecision is the outcome of negotiate.
+type sessionTimerDecision struct {
+	// Negotiated is the agreed session interval. It is also the Min-SE value to
+	// echo when rejecting a below-floor offer.
+	Negotiated time.Duration
+
+	// Interval is the refresh cadence: half the negotiated interval, clamped to
+	// minRefreshInterval.
+	Interval time.Duration
+
+	// Refresher is the elected refresher token: "uas", "uac", or "" for neutral.
+	Refresher string
+
+	// BelowFloor is true when an offered Session-Expires was strictly below the
+	// floor, signalling the answer path to reply 422.
+	BelowFloor bool
+
+	// WeRefresh is true when the elected refresher is our role: the caller runs
+	// the refresh loop, otherwise it arms the peer-refresh watchdog.
+	WeRefresh bool
+}
+
+// watchdogGrace resolves the peer-refresh watchdog grace from policy, falling
+// back to defaultWatchdogGrace when the field is zero. It is the single source
+// for the grace so call sites never pass a bare literal.
+func watchdogGrace(policy SessionTimerPolicy) time.Duration {
+	if policy.WatchdogGrace > 0 {
+		return policy.WatchdogGrace
+	}
+	return defaultWatchdogGrace
+}
+
+// negotiate is a pure, role-agnostic RFC 4028 session-timer negotiation. Given a
+// peer's offered Session-Expires, Min-SE and refresher plus our policy it floors
+// the interval by Min-SE, falls back to the advertise-fallback when nothing is
+// offered, halves for the refresh cadence, honors the peer's refresher and
+// elects ourRole when the peer omits one, and flags a below-floor offer for a
+// 422 reply. ourRole only decides WeRefresh, so the same
+// function serves the UAS answer path and a future UAC client path unchanged.
+//
+// All inputs are bounded uint32 deltas, so the duration arithmetic cannot
+// overflow.
+func negotiate(offeredSE *uint32, offeredMinSE *uint32, offeredRefresher string, policy SessionTimerPolicy, ourRole string) sessionTimerDecision {
+	// Effective floor: our Min-SE, raised by the peer's when it offered a higher
+	// one. Per RFC 4028 the floor is the max of both parties' minima, so the peer
+	// can raise the floor but never lower ours.
+	floor := policy.MinSE
+	if floor <= 0 {
+		floor = defaultMinSE
+	}
+	if offeredMinSE != nil {
+		if peerMin := time.Duration(*offeredMinSE) * time.Second; peerMin > floor {
+			floor = peerMin
+		}
+	}
+
+	// Candidate interval: the peer's offer, or our advertise-fallback when the
+	// peer is timer-supporting but offered no Session-Expires.
+	var (
+		candidate  time.Duration
+		belowFloor bool
+	)
+	if offeredSE != nil {
+		candidate = time.Duration(*offeredSE) * time.Second
+		// A strictly below-floor offer is flagged for a 422. The negotiated value
+		// still reports the floor, which is the Min-SE the answer path echoes.
+		belowFloor = candidate < floor
+	} else {
+		candidate = policy.DefaultSE
+		if candidate <= 0 {
+			candidate = defaultSessionExpires
+		}
+	}
+
+	// Clamp up to the floor so a below-floor offer never drives a sub-floor
+	// cadence.
+	negotiated := candidate
+	if negotiated < floor {
+		negotiated = floor
+	}
+
+	// Refresh at half the negotiated interval, clamped so no offer can storm the
+	// signaling path.
+	interval := negotiated / 2
+	if interval < minRefreshInterval {
+		interval = minRefreshInterval
+	}
+
+	// Honor the peer's offered refresher, and elect ourselves when it omits one.
+	// RFC 4028 section 9 requires the 2xx to name a refresher, and leaving it
+	// unset would arm the watchdog against a peer that was never asked to
+	// refresh -- it would then hang up at the interval plus grace on a healthy
+	// session.
+	refresher := offeredRefresher
+	if refresher == "" {
+		refresher = ourRole
+	}
+
+	return sessionTimerDecision{
+		Negotiated: negotiated,
+		Interval:   interval,
+		Refresher:  refresher,
+		BelowFloor: belowFloor,
+		WeRefresh:  refresher != "" && refresher == ourRole,
+	}
+}
+
+// sessionTimerOffer is a peer's parsed RFC 4028 offer.
+type sessionTimerOffer struct {
+	SE        *uint32
+	MinSE     *uint32
+	Refresher string
+}
+
+// parseSessionTimerOffer reads Session-Expires and Min-SE off a request. sipgo
+// carries no typed accessors for these headers, so they are read generically and
+// parsed here. A malformed or out-of-range value is treated as absent rather
+// than as an error: RFC 4028 §7.4 has the receiver ignore what it cannot parse,
+// and a timer header is never worth failing an otherwise valid INVITE over.
+// ok is false when the peer sent no Session-Expires at all (timer-unaware).
+func parseSessionTimerOffer(req *sip.Request) (offer sessionTimerOffer, ok bool) {
+	h := req.GetHeader("Session-Expires")
+	if h == nil {
+		// Compact form of Session-Expires per RFC 4028 §7.1.
+		h = req.GetHeader("x")
+	}
+	if h == nil {
+		return sessionTimerOffer{}, false
+	}
+
+	value, params, _ := strings.Cut(h.Value(), ";")
+	se, err := parseDeltaSeconds(value)
+	if err != nil {
+		return sessionTimerOffer{}, false
+	}
+	offer.SE = &se
+
+	for _, p := range strings.Split(params, ";") {
+		k, v, found := strings.Cut(p, "=")
+		if !found {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(k), "refresher") {
+			offer.Refresher = strings.ToLower(strings.TrimSpace(v))
+		}
+	}
+
+	if m := req.GetHeader("Min-SE"); m != nil {
+		// Min-SE may itself carry generic params; only the delta matters here.
+		mv, _, _ := strings.Cut(m.Value(), ";")
+		if minSE, err := parseDeltaSeconds(mv); err == nil {
+			offer.MinSE = &minSE
+		}
+	}
+
+	return offer, true
+}
+
+// parseDeltaSeconds parses an RFC 3261 delta-seconds value, the on-the-wire form
+// of Session-Expires and Min-SE. It rejects anything that does not fit the
+// unsigned 32-bit range the negotiation arithmetic assumes.
+func parseDeltaSeconds(s string) (uint32, error) {
+	v, err := strconv.ParseUint(strings.TrimSpace(s), 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
+}
+
+// secondsOf renders a session-timer duration as integer delta-seconds, the
+// on-the-wire form for Session-Expires and Min-SE header values.
+func secondsOf(d time.Duration) string {
+	return strconv.FormatInt(int64(d/time.Second), 10)
+}
+
+// sessionRefreshLoop drives the RFC 4028 in-dialog refresh when we are the
+// elected refresher. It ticks every interval and runs refresh. Unlike a liveness
+// probe, which tolerates blips and counts to a threshold, a failed session
+// refresh means the dialog is at risk, so it escalates on the first refresh
+// error. Cancellation of ctx (dialog Close or Bye) is surfaced as the context
+// error and takes precedence over a refresh error observed during shutdown, so
+// the goroutine always exits cleanly with the dialog.
+func sessionRefreshLoop(ctx context.Context, interval time.Duration, refresh func(context.Context) error) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+
+		if err := refresh(ctx); err != nil {
+			if ctx.Err() != nil {
+				// Cancellation during the refresh is a clean teardown, never a
+				// peer-failure signal, so surface the context error.
+				return ctx.Err()
+			}
+			return err
+		}
+	}
+}
+
+// peerRefreshWatchdog bounds the case where the peer is the elected refresher
+// and stops refreshing. It fires sendBye exactly once if no inbound refresh
+// resets it within negotiatedSE plus grace, and is cancellable via ctx (dialog
+// Close or Bye) or Stop. The caller supplies the hangup action and resets it on
+// an inbound refresh re-INVITE.
+type peerRefreshWatchdog struct {
+	resetCh chan struct{}
+	stopCh  chan struct{}
+	done    chan struct{}
+	stopOne sync.Once
+	fired   atomic.Bool
+}
+
+// armPeerRefreshWatchdog starts a peer-refresh watchdog that hangs up the dialog
+// via sendBye if no Reset arrives within negotiatedSE plus grace. Resolve grace
+// from policy via watchdogGrace rather than passing a literal. The watchdog exits
+// on ctx cancel, on Stop, or after it fires.
+func armPeerRefreshWatchdog(ctx context.Context, negotiatedSE, grace time.Duration, sendBye func(context.Context) error) *peerRefreshWatchdog {
+	w := &peerRefreshWatchdog{
+		resetCh: make(chan struct{}, 1),
+		stopCh:  make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	go w.run(ctx, negotiatedSE+grace, sendBye)
+	return w
+}
+
+// run is the watchdog control loop. It rearms its expiry timer on every Reset and
+// fires sendBye at most once when the timer elapses with no reset.
+func (w *peerRefreshWatchdog) run(ctx context.Context, expiry time.Duration, sendBye func(context.Context) error) {
+	defer close(w.done)
+
+	timer := time.NewTimer(expiry)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-w.resetCh:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(expiry)
+		case <-timer.C:
+			if w.fired.CompareAndSwap(false, true) {
+				// Best effort: the dialog is being torn down regardless, and a BYE
+				// error on a dying dialog is not actionable here.
+				_ = sendBye(ctx)
+			}
+			return
+		}
+	}
+}
+
+// Reset rearms the watchdog to its full negotiatedSE plus grace window. It is
+// called on an inbound refresh re-INVITE and is safe to call from any goroutine.
+// A reset that races a pending one is coalesced, since the window is rearmed
+// either way.
+func (w *peerRefreshWatchdog) Reset() {
+	select {
+	case w.resetCh <- struct{}{}:
+	default:
+	}
+}
+
+// Stop tears the watchdog down without firing a BYE. It is idempotent and safe
+// to call alongside ctx cancellation.
+func (w *peerRefreshWatchdog) Stop() {
+	w.stopOne.Do(func() { close(w.stopCh) })
+}

--- a/session_timers_test.go
+++ b/session_timers_test.go
@@ -188,7 +188,7 @@ func TestPeerRefreshWatchdog_GraceResolvesViaPolicy(t *testing.T) {
 // TestSessionTimerNegotiate exercises the pure, role-agnostic RFC 4028
 // negotiation: the Min-SE floor, the advertise-fallback when nothing is offered,
 // the half refresh interval with anti-storm clamp, honoring the peer's
-// refresher, electing ourselves when the peer omits one, and
+// refresher, the PreferUASRefresher tiebreaker only when the peer omits one, and
 // the below-floor 422 signal.
 func TestSessionTimerNegotiate(t *testing.T) {
 	tests := []struct {
@@ -201,8 +201,8 @@ func TestSessionTimerNegotiate(t *testing.T) {
 		want             sessionTimerDecision
 	}{
 		{
-			name:    "none offered uses advertise-fallback, uas elected, we refresh",
-			policy:  SessionTimerPolicy{},
+			name:    "none offered uses advertise-fallback, uas tiebreaker, we refresh",
+			policy:  SessionTimerPolicy{PreferUASRefresher: true},
 			ourRole: refresherUAS,
 			want: sessionTimerDecision{
 				Negotiated: defaultSessionExpires,
@@ -215,7 +215,7 @@ func TestSessionTimerNegotiate(t *testing.T) {
 			name:             "peer refresher honored over our preference",
 			offeredSE:        u32(1200),
 			offeredRefresher: refresherUAC,
-			policy:           SessionTimerPolicy{},
+			policy:           SessionTimerPolicy{PreferUASRefresher: true},
 			ourRole:          refresherUAS,
 			want: sessionTimerDecision{
 				Negotiated: 1200 * time.Second,
@@ -225,13 +225,9 @@ func TestSessionTimerNegotiate(t *testing.T) {
 			},
 		},
 		{
-			// RFC 4028 section 9 requires the 2xx to name a refresher. Leaving it
-			// unset would arm the watchdog against a peer that was never asked to
-			// refresh, so it would hang up at the interval plus grace on a
-			// perfectly healthy session.
-			name:      "no peer refresher -> the UAS elects itself",
+			name:      "no peer refresher, PreferUAS true -> uas tiebreaker",
 			offeredSE: u32(1800),
-			policy:    SessionTimerPolicy{},
+			policy:    SessionTimerPolicy{PreferUASRefresher: true},
 			ourRole:   refresherUAS,
 			want: sessionTimerDecision{
 				Negotiated: 1800 * time.Second,
@@ -241,9 +237,21 @@ func TestSessionTimerNegotiate(t *testing.T) {
 			},
 		},
 		{
+			name:      "no peer refresher, PreferUAS false -> neutral, not forced uas",
+			offeredSE: u32(1800),
+			policy:    SessionTimerPolicy{PreferUASRefresher: false},
+			ourRole:   refresherUAS,
+			want: sessionTimerDecision{
+				Negotiated: 1800 * time.Second,
+				Interval:   900 * time.Second,
+				Refresher:  "",
+				WeRefresh:  false,
+			},
+		},
+		{
 			name:      "offer below floor -> below-floor 422 signal, negotiated reports the floor",
 			offeredSE: u32(30),
-			policy:    SessionTimerPolicy{},
+			policy:    SessionTimerPolicy{PreferUASRefresher: true},
 			ourRole:   refresherUAS,
 			want: sessionTimerDecision{
 				Negotiated: defaultMinSE,
@@ -257,7 +265,7 @@ func TestSessionTimerNegotiate(t *testing.T) {
 			name:         "peer Min-SE raises the floor above ours",
 			offeredSE:    u32(1800),
 			offeredMinSE: u32(120),
-			policy:       SessionTimerPolicy{},
+			policy:       SessionTimerPolicy{PreferUASRefresher: true},
 			ourRole:      refresherUAS,
 			want: sessionTimerDecision{
 				Negotiated: 1800 * time.Second,
@@ -270,7 +278,7 @@ func TestSessionTimerNegotiate(t *testing.T) {
 			name:         "peer Min-SE above the offer raises the negotiated interval",
 			offeredSE:    u32(100),
 			offeredMinSE: u32(600),
-			policy:       SessionTimerPolicy{},
+			policy:       SessionTimerPolicy{PreferUASRefresher: true},
 			ourRole:      refresherUAS,
 			want: sessionTimerDecision{
 				Negotiated: 600 * time.Second,
@@ -282,7 +290,7 @@ func TestSessionTimerNegotiate(t *testing.T) {
 		},
 		{
 			name:    "configurable DefaultSE advertise-fallback is used, not the constant",
-			policy:  SessionTimerPolicy{DefaultSE: 600 * time.Second},
+			policy:  SessionTimerPolicy{DefaultSE: 600 * time.Second, PreferUASRefresher: true},
 			ourRole: refresherUAS,
 			want: sessionTimerDecision{
 				Negotiated: 600 * time.Second,
@@ -474,7 +482,7 @@ func TestTimerAnswer(t *testing.T) {
 			// uas, we are not the refresher, so the decision is to arm the watchdog.
 			name:            "honor peer refresher=uac -> arm watchdog",
 			se:              "1800;refresher=uac",
-			policy:          SessionTimerPolicy{Enabled: true},
+			policy:          SessionTimerPolicy{Enabled: true, PreferUASRefresher: true},
 			wantStatus:      200,
 			wantSE:          "1800;refresher=uac",
 			wantSupported:   true,
@@ -483,11 +491,11 @@ func TestTimerAnswer(t *testing.T) {
 			wantArmWatchdog: true,
 		},
 		{
-			// Peer omitted the refresher: the UAS elects
+			// Peer omitted the refresher: the PreferUASRefresher tiebreaker elects
 			// uas, we are the refresher, so the decision is to start the loop.
-			name:            "omitted refresher -> uas elected, start loop",
+			name:            "omitted refresher, PreferUAS -> refresher=uas, start loop",
 			se:              "1800",
-			policy:          SessionTimerPolicy{Enabled: true},
+			policy:          SessionTimerPolicy{Enabled: true, PreferUASRefresher: true},
 			wantStatus:      200,
 			wantSE:          "1800;refresher=uas",
 			wantSupported:   true,
@@ -500,7 +508,7 @@ func TestTimerAnswer(t *testing.T) {
 			// no loop and no watchdog.
 			name:       "offer below floor -> 422 Min-SE, no loop/watchdog",
 			se:         "30",
-			policy:     SessionTimerPolicy{Enabled: true},
+			policy:     SessionTimerPolicy{Enabled: true, PreferUASRefresher: true},
 			wantStatus: 422,
 			wantMinSE:  "90",
 			wantAnswer: false,
@@ -510,7 +518,7 @@ func TestTimerAnswer(t *testing.T) {
 			// no watchdog, answered normally and never rejected.
 			name:          "no timer support -> graceful no-op",
 			se:            "",
-			policy:        SessionTimerPolicy{Enabled: true},
+			policy:        SessionTimerPolicy{Enabled: true, PreferUASRefresher: true},
 			wantStatus:    200,
 			wantSE:        "",
 			wantSupported: false,
@@ -519,7 +527,7 @@ func TestTimerAnswer(t *testing.T) {
 		{
 			name:          "timers disabled -> no headers",
 			se:            "1800",
-			policy:        SessionTimerPolicy{Enabled: false},
+			policy:        SessionTimerPolicy{Enabled: false, PreferUASRefresher: true},
 			wantStatus:    200,
 			wantSE:        "",
 			wantSupported: false,
@@ -591,7 +599,7 @@ func TestTimerAnswer(t *testing.T) {
 // is what the dialog construction path reads. Without the option timers stay
 // disabled, preserving the existing behavior for callers that never opt in.
 func TestWithSessionTimers(t *testing.T) {
-	policy := SessionTimerPolicy{Enabled: true, DefaultSE: 600 * time.Second}
+	policy := SessionTimerPolicy{Enabled: true, DefaultSE: 600 * time.Second, PreferUASRefresher: true}
 
 	dg := &Diago{}
 	WithSessionTimers(policy)(dg)

--- a/session_timers_test.go
+++ b/session_timers_test.go
@@ -1,0 +1,606 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package diago
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/emiago/sipgo/sip"
+)
+
+// errRefresh is a stand-in session-refresh failure returned by the fake refresh.
+var errRefresh = errors.New("session refresh failed")
+
+// u32 returns a pointer to the given uint32, for building offered header values.
+func u32(v uint32) *uint32 { return &v }
+
+// --- sessionRefreshLoop ------------------------------------------------------
+
+// TestSessionRefreshLoop_EscalatesOnFirstRefreshError verifies the loop returns
+// the refresh error immediately on the first failure. There is no failure
+// counter: a failed re-INVITE means the dialog is at risk, unlike a tolerated
+// liveness blip.
+func TestSessionRefreshLoop_EscalatesOnFirstRefreshError(t *testing.T) {
+	calls := 0
+	refresh := func(context.Context) error {
+		calls++
+		return errRefresh
+	}
+
+	err := sessionRefreshLoop(context.Background(), time.Millisecond, refresh)
+
+	if !errors.Is(err, errRefresh) {
+		t.Fatalf("err = %v, want errRefresh", err)
+	}
+	if calls != 1 {
+		t.Fatalf("refresh called %d times, want exactly 1 (escalate on first error)", calls)
+	}
+}
+
+// TestSessionRefreshLoop_ExitsOnContextCancel verifies the loop returns the
+// context error rather than a refresh escalation when ctx is cancelled, such as
+// on dialog Close or Bye, and that the goroutine exits.
+func TestSessionRefreshLoop_ExitsOnContextCancel(t *testing.T) {
+	refresh := func(context.Context) error { return nil }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- sessionRefreshLoop(ctx, time.Millisecond, refresh) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("err = %v, want context.DeadlineExceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not exit within 2s of context cancel")
+	}
+}
+
+// TestSessionRefreshLoop_ContextCancelDuringRefreshTakesPrecedence verifies that
+// a refresh failing because its ctx was cancelled mid-call is surfaced as the
+// context error, never the refresh error. Clean shutdown takes precedence.
+func TestSessionRefreshLoop_ContextCancelDuringRefreshTakesPrecedence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	refresh := func(context.Context) error {
+		cancel()
+		return errRefresh
+	}
+
+	err := sessionRefreshLoop(ctx, time.Millisecond, refresh)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled (ctx error precedence)", err)
+	}
+}
+
+// --- armPeerRefreshWatchdog ---------------------------------------------------
+
+// TestPeerRefreshWatchdog_FiresByeOnExpiry verifies a watchdog with no reset
+// hangs up exactly once within the expiry window and then its goroutine exits.
+func TestPeerRefreshWatchdog_FiresByeOnExpiry(t *testing.T) {
+	byeCh := make(chan struct{}, 2)
+	sendBye := func(context.Context) error {
+		byeCh <- struct{}{}
+		return nil
+	}
+
+	w := armPeerRefreshWatchdog(context.Background(), 20*time.Millisecond, 20*time.Millisecond, sendBye)
+	defer w.Stop()
+
+	select {
+	case <-byeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not BYE within 2s of expiry")
+	}
+
+	// Single shot: it must not fire a second BYE.
+	select {
+	case <-byeCh:
+		t.Fatal("watchdog fired BYE more than once")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case <-w.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog goroutine did not exit after firing")
+	}
+}
+
+// TestPeerRefreshWatchdog_ResetPreventsBye verifies that periodic Reset before
+// expiry keeps the dialog alive, so sendBye is never called during the window.
+func TestPeerRefreshWatchdog_ResetPreventsBye(t *testing.T) {
+	var byes atomic.Int32
+	sendBye := func(context.Context) error {
+		byes.Add(1)
+		return nil
+	}
+
+	// expiry 100ms, resetting every 25ms must keep it armed.
+	w := armPeerRefreshWatchdog(context.Background(), 100*time.Millisecond, 0, sendBye)
+
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		w.Reset()
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	if got := byes.Load(); got != 0 {
+		t.Fatalf("watchdog fired %d BYEs during the reset window, want 0", got)
+	}
+
+	w.Stop()
+	select {
+	case <-w.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog goroutine did not exit after Stop")
+	}
+}
+
+// TestPeerRefreshWatchdog_ExitsOnContextCancel verifies the watchdog exits on ctx
+// cancel without firing a BYE, covering a dialog torn down before the
+// peer-refresh window elapses.
+func TestPeerRefreshWatchdog_ExitsOnContextCancel(t *testing.T) {
+	var byes atomic.Int32
+	sendBye := func(context.Context) error {
+		byes.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Long expiry so only ctx cancel can end the watchdog.
+	w := armPeerRefreshWatchdog(ctx, 10*time.Second, 0, sendBye)
+	cancel()
+
+	select {
+	case <-w.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not exit within 2s of context cancel")
+	}
+
+	if got := byes.Load(); got != 0 {
+		t.Fatalf("watchdog fired %d BYEs on ctx-cancel, want 0", got)
+	}
+}
+
+// TestPeerRefreshWatchdog_GraceResolvesViaPolicy verifies the grace source: the
+// policy field wins when set, otherwise the constant fallback applies.
+func TestPeerRefreshWatchdog_GraceResolvesViaPolicy(t *testing.T) {
+	if got := watchdogGrace(SessionTimerPolicy{}); got != defaultWatchdogGrace {
+		t.Fatalf("watchdogGrace(zero) = %v, want %v", got, defaultWatchdogGrace)
+	}
+	if got := watchdogGrace(SessionTimerPolicy{WatchdogGrace: 3 * time.Second}); got != 3*time.Second {
+		t.Fatalf("watchdogGrace(3s) = %v, want 3s", got)
+	}
+}
+
+// --- negotiate ----------------------------------------------------------------
+
+// TestSessionTimerNegotiate exercises the pure, role-agnostic RFC 4028
+// negotiation: the Min-SE floor, the advertise-fallback when nothing is offered,
+// the half refresh interval with anti-storm clamp, honoring the peer's
+// refresher, electing ourselves when the peer omits one, and
+// the below-floor 422 signal.
+func TestSessionTimerNegotiate(t *testing.T) {
+	tests := []struct {
+		name             string
+		offeredSE        *uint32
+		offeredMinSE     *uint32
+		offeredRefresher string
+		policy           SessionTimerPolicy
+		ourRole          string
+		want             sessionTimerDecision
+	}{
+		{
+			name:    "none offered uses advertise-fallback, uas elected, we refresh",
+			policy:  SessionTimerPolicy{},
+			ourRole: refresherUAS,
+			want: sessionTimerDecision{
+				Negotiated: defaultSessionExpires,
+				Interval:   defaultSessionExpires / 2,
+				Refresher:  refresherUAS,
+				WeRefresh:  true,
+			},
+		},
+		{
+			name:             "peer refresher honored over our preference",
+			offeredSE:        u32(1200),
+			offeredRefresher: refresherUAC,
+			policy:           SessionTimerPolicy{},
+			ourRole:          refresherUAS,
+			want: sessionTimerDecision{
+				Negotiated: 1200 * time.Second,
+				Interval:   600 * time.Second,
+				Refresher:  refresherUAC,
+				WeRefresh:  false,
+			},
+		},
+		{
+			// RFC 4028 section 9 requires the 2xx to name a refresher. Leaving it
+			// unset would arm the watchdog against a peer that was never asked to
+			// refresh, so it would hang up at the interval plus grace on a
+			// perfectly healthy session.
+			name:      "no peer refresher -> the UAS elects itself",
+			offeredSE: u32(1800),
+			policy:    SessionTimerPolicy{},
+			ourRole:   refresherUAS,
+			want: sessionTimerDecision{
+				Negotiated: 1800 * time.Second,
+				Interval:   900 * time.Second,
+				Refresher:  refresherUAS,
+				WeRefresh:  true,
+			},
+		},
+		{
+			name:      "offer below floor -> below-floor 422 signal, negotiated reports the floor",
+			offeredSE: u32(30),
+			policy:    SessionTimerPolicy{},
+			ourRole:   refresherUAS,
+			want: sessionTimerDecision{
+				Negotiated: defaultMinSE,
+				Interval:   defaultMinSE / 2,
+				Refresher:  refresherUAS,
+				BelowFloor: true,
+				WeRefresh:  true,
+			},
+		},
+		{
+			name:         "peer Min-SE raises the floor above ours",
+			offeredSE:    u32(1800),
+			offeredMinSE: u32(120),
+			policy:       SessionTimerPolicy{},
+			ourRole:      refresherUAS,
+			want: sessionTimerDecision{
+				Negotiated: 1800 * time.Second,
+				Interval:   900 * time.Second,
+				Refresher:  refresherUAS,
+				WeRefresh:  true,
+			},
+		},
+		{
+			name:         "peer Min-SE above the offer raises the negotiated interval",
+			offeredSE:    u32(100),
+			offeredMinSE: u32(600),
+			policy:       SessionTimerPolicy{},
+			ourRole:      refresherUAS,
+			want: sessionTimerDecision{
+				Negotiated: 600 * time.Second,
+				Interval:   300 * time.Second,
+				Refresher:  refresherUAS,
+				BelowFloor: true,
+				WeRefresh:  true,
+			},
+		},
+		{
+			name:    "configurable DefaultSE advertise-fallback is used, not the constant",
+			policy:  SessionTimerPolicy{DefaultSE: 600 * time.Second},
+			ourRole: refresherUAS,
+			want: sessionTimerDecision{
+				Negotiated: 600 * time.Second,
+				Interval:   300 * time.Second,
+				Refresher:  refresherUAS,
+				WeRefresh:  true,
+			},
+		},
+		{
+			name:             "we are uac and peer elected uac -> we refresh",
+			offeredSE:        u32(1800),
+			offeredRefresher: refresherUAC,
+			policy:           SessionTimerPolicy{},
+			ourRole:          refresherUAC,
+			want: sessionTimerDecision{
+				Negotiated: 1800 * time.Second,
+				Interval:   900 * time.Second,
+				Refresher:  refresherUAC,
+				WeRefresh:  true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := negotiate(tt.offeredSE, tt.offeredMinSE, tt.offeredRefresher, tt.policy, tt.ourRole)
+			if got != tt.want {
+				t.Fatalf("negotiate() = %+v, want %+v", got, tt.want)
+			}
+			// Anti-storm: the refresh cadence is never sub-floor, even for a tiny
+			// offer.
+			if got.Interval < minRefreshInterval {
+				t.Fatalf("Interval = %v, want >= minRefreshInterval %v", got.Interval, minRefreshInterval)
+			}
+		})
+	}
+}
+
+// --- parseSessionTimerOffer ---------------------------------------------------
+
+// TestParseSessionTimerOffer pins the header shim that stands in for the typed
+// accessors sipgo does not provide: the delta and refresher param are read off
+// Session-Expires, Min-SE is optional, the compact form "x" is accepted, and a
+// malformed value is treated as absent rather than as an error.
+func TestParseSessionTimerOffer(t *testing.T) {
+	tests := []struct {
+		name          string
+		headers       [][2]string
+		wantOK        bool
+		wantSE        *uint32
+		wantMinSE     *uint32
+		wantRefresher string
+	}{
+		{
+			name:          "delta with refresher param",
+			headers:       [][2]string{{"Session-Expires", "1800;refresher=uac"}},
+			wantOK:        true,
+			wantSE:        u32(1800),
+			wantRefresher: refresherUAC,
+		},
+		{
+			name:    "bare delta, no params",
+			headers: [][2]string{{"Session-Expires", "1800"}},
+			wantOK:  true,
+			wantSE:  u32(1800),
+		},
+		{
+			name:          "refresher param is case insensitive",
+			headers:       [][2]string{{"Session-Expires", "1800;REFRESHER=UAS"}},
+			wantOK:        true,
+			wantSE:        u32(1800),
+			wantRefresher: refresherUAS,
+		},
+		{
+			name:      "Min-SE is parsed alongside",
+			headers:   [][2]string{{"Session-Expires", "1800"}, {"Min-SE", "120"}},
+			wantOK:    true,
+			wantSE:    u32(1800),
+			wantMinSE: u32(120),
+		},
+		{
+			name:          "compact form x is accepted",
+			headers:       [][2]string{{"x", "1800;refresher=uas"}},
+			wantOK:        true,
+			wantSE:        u32(1800),
+			wantRefresher: refresherUAS,
+		},
+		{
+			name:    "no Session-Expires means timer-unaware peer",
+			headers: nil,
+			wantOK:  false,
+		},
+		{
+			name:    "malformed delta is treated as absent, never an error",
+			headers: [][2]string{{"Session-Expires", "not-a-number"}},
+			wantOK:  false,
+		},
+		{
+			name:    "out-of-range delta is treated as absent",
+			headers: [][2]string{{"Session-Expires", "4294967296"}},
+			wantOK:  false,
+		},
+		{
+			name:      "malformed Min-SE is ignored, Session-Expires still stands",
+			headers:   [][2]string{{"Session-Expires", "1800"}, {"Min-SE", "bogus"}},
+			wantOK:    true,
+			wantSE:    u32(1800),
+			wantMinSE: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := sip.NewRequest(sip.INVITE, sip.Uri{User: "alice", Host: "example.com"})
+			for _, h := range tt.headers {
+				req.AppendHeader(sip.NewHeader(h[0], h[1]))
+			}
+
+			offer, ok := parseSessionTimerOffer(req)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got, want := derefU32(offer.SE), derefU32(tt.wantSE); got != want {
+				t.Fatalf("SE = %v, want %v", got, want)
+			}
+			if got, want := derefU32(offer.MinSE), derefU32(tt.wantMinSE); got != want {
+				t.Fatalf("MinSE = %v, want %v", got, want)
+			}
+			if offer.Refresher != tt.wantRefresher {
+				t.Fatalf("Refresher = %q, want %q", offer.Refresher, tt.wantRefresher)
+			}
+		})
+	}
+}
+
+// derefU32 renders an optional uint32 as a comparable value, using -1 for nil so
+// "absent" and zero stay distinguishable in test failures.
+func derefU32(p *uint32) int64 {
+	if p == nil {
+		return -1
+	}
+	return int64(*p)
+}
+
+// --- buildTimerAnswer ---------------------------------------------------------
+
+// inviteWithSE builds a minimal INVITE carrying the given Session-Expires value.
+// An empty se models a timer-unaware peer that sent no Session-Expires.
+func inviteWithSE(se string) *sip.Request {
+	req := sip.NewRequest(sip.INVITE, sip.Uri{User: "alice", Host: "example.com"})
+	if se != "" {
+		req.AppendHeader(sip.NewHeader("Session-Expires", se))
+	}
+	return req
+}
+
+// answerHeader returns the value of the first answer header matching name.
+func answerHeader(hdrs []sip.Header, name string) (string, bool) {
+	for _, h := range hdrs {
+		if strings.EqualFold(h.Name(), name) {
+			return h.Value(), true
+		}
+	}
+	return "", false
+}
+
+// TestTimerAnswer pins the answer-path decision over the pure buildTimerAnswer
+// helper: honor the peer's offered refresher, advertise Supported: timer and
+// never Require: timer, reject below-floor with 422 plus Min-SE, no-op
+// gracefully for a timer-unaware peer, and elect loop versus watchdog.
+func TestTimerAnswer(t *testing.T) {
+	tests := []struct {
+		name            string
+		se              string
+		policy          SessionTimerPolicy
+		wantStatus      int
+		wantSE          string // expected Session-Expires value, "" means none expected
+		wantSupported   bool
+		wantMinSE       string // expected Min-SE value on a 422, "" means none
+		wantAnswer      bool
+		wantWeRefresh   bool
+		wantArmWatchdog bool
+	}{
+		{
+			// Peer offered refresher=uac: the answer honors uac rather than forcing
+			// uas, we are not the refresher, so the decision is to arm the watchdog.
+			name:            "honor peer refresher=uac -> arm watchdog",
+			se:              "1800;refresher=uac",
+			policy:          SessionTimerPolicy{Enabled: true},
+			wantStatus:      200,
+			wantSE:          "1800;refresher=uac",
+			wantSupported:   true,
+			wantAnswer:      true,
+			wantWeRefresh:   false,
+			wantArmWatchdog: true,
+		},
+		{
+			// Peer omitted the refresher: the UAS elects
+			// uas, we are the refresher, so the decision is to start the loop.
+			name:            "omitted refresher -> uas elected, start loop",
+			se:              "1800",
+			policy:          SessionTimerPolicy{Enabled: true},
+			wantStatus:      200,
+			wantSE:          "1800;refresher=uas",
+			wantSupported:   true,
+			wantAnswer:      true,
+			wantWeRefresh:   true,
+			wantArmWatchdog: false,
+		},
+		{
+			// Below the 90s floor: 422 Session Interval Too Small plus Min-SE 90,
+			// no loop and no watchdog.
+			name:       "offer below floor -> 422 Min-SE, no loop/watchdog",
+			se:         "30",
+			policy:     SessionTimerPolicy{Enabled: true},
+			wantStatus: 422,
+			wantMinSE:  "90",
+			wantAnswer: false,
+		},
+		{
+			// Timer-unaware peer: graceful no-op with no timer headers, no loop and
+			// no watchdog, answered normally and never rejected.
+			name:          "no timer support -> graceful no-op",
+			se:            "",
+			policy:        SessionTimerPolicy{Enabled: true},
+			wantStatus:    200,
+			wantSE:        "",
+			wantSupported: false,
+			wantAnswer:    false,
+		},
+		{
+			name:          "timers disabled -> no headers",
+			se:            "1800",
+			policy:        SessionTimerPolicy{Enabled: false},
+			wantStatus:    200,
+			wantSE:        "",
+			wantSupported: false,
+			wantAnswer:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ta, hdrs, status := buildTimerAnswer(inviteWithSE(tt.se), tt.policy)
+
+			if status != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", status, tt.wantStatus)
+			}
+			if (ta != nil) != tt.wantAnswer {
+				t.Fatalf("answer present = %v, want %v", ta != nil, tt.wantAnswer)
+			}
+			if ta != nil {
+				if ta.weRefresh != tt.wantWeRefresh {
+					t.Fatalf("weRefresh = %v, want %v", ta.weRefresh, tt.wantWeRefresh)
+				}
+				if ta.armWatchdog != tt.wantArmWatchdog {
+					t.Fatalf("armWatchdog = %v, want %v", ta.armWatchdog, tt.wantArmWatchdog)
+				}
+			}
+
+			// We advertise Supported: timer and never Require: timer, so a
+			// timer-unaware peer is never rejected for lacking timer support.
+			if _, ok := answerHeader(hdrs, "Require"); ok {
+				t.Fatalf("answer must never carry Require: timer; headers=%v", hdrs)
+			}
+
+			if tt.wantSE != "" {
+				gotSE, ok := answerHeader(hdrs, "Session-Expires")
+				if !ok {
+					t.Fatalf("missing Session-Expires header; headers=%v", hdrs)
+				}
+				if gotSE != tt.wantSE {
+					t.Fatalf("Session-Expires = %q, want %q", gotSE, tt.wantSE)
+				}
+			} else if gotSE, ok := answerHeader(hdrs, "Session-Expires"); ok {
+				t.Fatalf("unexpected Session-Expires = %q, want none", gotSE)
+			}
+
+			_, gotSupported := answerHeader(hdrs, "Supported")
+			if gotSupported != tt.wantSupported {
+				t.Fatalf("Supported present = %v, want %v; headers=%v", gotSupported, tt.wantSupported, hdrs)
+			}
+			if tt.wantSupported {
+				if v, _ := answerHeader(hdrs, "Supported"); v != "timer" {
+					t.Fatalf("Supported = %q, want \"timer\"", v)
+				}
+			}
+
+			if tt.wantMinSE != "" {
+				gotMinSE, ok := answerHeader(hdrs, "Min-SE")
+				if !ok {
+					t.Fatalf("missing Min-SE header on 422; headers=%v", hdrs)
+				}
+				if gotMinSE != tt.wantMinSE {
+					t.Fatalf("Min-SE = %q, want %q", gotMinSE, tt.wantMinSE)
+				}
+			}
+		})
+	}
+}
+
+// TestWithSessionTimers verifies the option stamps the policy onto Diago, which
+// is what the dialog construction path reads. Without the option timers stay
+// disabled, preserving the existing behavior for callers that never opt in.
+func TestWithSessionTimers(t *testing.T) {
+	policy := SessionTimerPolicy{Enabled: true, DefaultSE: 600 * time.Second}
+
+	dg := &Diago{}
+	WithSessionTimers(policy)(dg)
+
+	if dg.sessionTimers != policy {
+		t.Fatalf("sessionTimers = %+v, want %+v", dg.sessionTimers, policy)
+	}
+
+	if (&Diago{}).sessionTimers.Enabled {
+		t.Fatal("session timers must be disabled without the option")
+	}
+}


### PR DESCRIPTION
Fixes #170

Adds session-timer negotiation to `Answer` and `AnswerOptions`. **Inert unless `SessionTimerPolicy.Enabled` is set** via `WithSessionTimers`; `AnswerLate` is unchanged and negotiates nothing.

The interval floors at `max(our Min-SE or 90s, the peer offered Min-SE)`, uses the peer `Session-Expires` when present, and an advertised default only when a timer-supporting peer offers none. The 200 OK carries `Session-Expires` with the elected refresher plus `Supported: timer`, never `Require: timer`. When elected refresher a loop re-INVITEs at half the interval, clamped to 45s minimum; otherwise a watchdog hangs up if no refresh arrives within the interval plus a grace, and an inbound refresh re-INVITE rearms it. Both run on the dialog context. A below-floor offer is answered 422 with `Min-SE` (RFC 4028 section 6) and aborts the answer. A timer-unaware peer is answered normally.

**Scope, stated plainly:** this is the UAS answer path only. There is no client-side timer code, no `Session-Expires` on an outbound INVITE, and no handling of a received 422. So it is "UAS-side session timer negotiation", not RFC 4028 support, and I would not add 4028 to the README on the strength of it.

`negotiate` and `buildTimerAnswer` are pure functions with no SIP-transaction dependency, so the decision logic is unit-testable without a PBX.

One thing I fixed before sending rather than shipping as-is: our own default policy had a footgun. It carried a `PreferUASRefresher` tiebreaker that only elected `uas` when set, so a zero-value policy against a peer offering `Session-Expires` with no refresher elected **nobody** — and then armed the watchdog anyway, hanging up a healthy session at the interval plus grace. RFC 4028 section 9 requires the UAS to name a refresher in the 2xx, so the UAS now always elects itself when the peer omits one, and the knob is gone. That deletes a field rather than adding one.

Needs sipgo `Session-Expires`/`Min-SE` header types (emiago/sipgo#334) or the headers get parsed here through `GetHeader` — currently the latter.