### PR TITLE
fix(media): use NTP seconds for SDP o= session id (full 64-bit NTP overflows int64 -> 488)

### DIFF
--- a/media/media_session.go
+++ b/media/media_session.go
@@ -409,7 +409,9 @@ func (s *MediaSession) LocalSDP() []byte {
 	}
 
 	if s.sessionID == 0 {
-		s.sessionID = GetCurrentNTPTimestamp()
+		// Use NTP seconds for the SDP o= session id (mainstream practice); the full 64-bit
+		// NTP value exceeds int64 when parsed as signed, breaking strict peers (488).
+		s.sessionID = GetCurrentNTPTimestamp() >> 32
 		s.sessionVersion = s.sessionID
 	} else {
 		s.sessionVersion++


### PR DESCRIPTION
## Problem

`MediaSession.LocalSDP()` derives the SDP `o=` session id from `GetCurrentNTPTimestamp()` in `media/rtp_utils.go`, which returns the **full 64-bit NTP timestamp** `(seconds << 32) | fraction` (≈ 1.7×10¹⁹, already beyond the int64 range). That 64-bit form is meant for RTP packet headers, not for the SDP `o=` line.

RFC 4566 §5.2 only requires `<sess-id>` to be "a numeric string such that the tuple ... forms a globally unique identifier"; allocation is "up to the creating tool" and an NTP timestamp is merely *suggested* (with no width constraint). So the current value is not *technically* invalid. In practice, however, mainstream SIP stacks (pjmedia, Asterisk, FreeSWITCH, linphone, …) all emit the **NTP seconds** value (≤ 32 bits, ≈ 4×10⁹ today), and some strict peers parse `<sess-id>` as a signed 64-bit integer. A value of ~1.7×10¹⁹ exceeds int64 (9223372036854775807) and breaks those peers.

## Symptom

Some PBX/SBC implementations parse the session id as a signed integer, overflow, fail SDP parsing, and respond **488 Not Acceptable Here with no `Warning` header and empty body** (the offer is rejected before answer/auth, so not even a 407 challenge is sent).

- diago: `o=- 17154221214847509312 ...` (> int64 max) → bare **488**
- Telephone 1.6 (pjmedia): `o=- 3994029403 ...` (NTP seconds) → success

## Fix

Keep only the high 32 bits (NTP seconds), aligning with mainstream practice and staying well within int64:

```diff
--- a/media/media_session.go
+++ b/media/media_session.go
@@ -411,7 +411,9 @@ func (s *MediaSession) LocalSDP() []byte {

        if s.sessionID == 0 {
-               s.sessionID = GetCurrentNTPTimestamp()
+               // Use NTP seconds for the SDP o= session id (mainstream practice); the full 64-bit
+               // NTP value exceeds int64 when parsed as signed, breaking strict peers (488).
+               s.sessionID = GetCurrentNTPTimestamp() >> 32
                s.sessionVersion = s.sessionID
        } else {
                s.sessionVersion++
```

## Verification

After the fix, `MediaSession.LocalSDP()` emits `o=- 3994030270 ...` (NTP seconds, same magnitude as pjmedia); the bare 488 from the PBX/SBC is resolved — the INVITE now proceeds to 407/180/200.