### PR TITLE
media: add MediaSession.OnWriteRTP to observe outgoing packets

### DIFF
--- a/media/media_session.go
+++ b/media/media_session.go
@@ -148,6 +148,9 @@ type MediaSession struct {
 	// DTLS
 	dtlsConn *dtls.Conn
 
+	// onWriteRTP observes every outgoing RTP packet. See OnWriteRTP.
+	onWriteRTP atomic.Pointer[rtpWriteObserver]
+
 	onFinalize func() error
 
 	sessionID      uint64
@@ -989,6 +992,10 @@ func (m *MediaSession) WriteRTP(p *rtp.Packet) error {
 	}
 
 	logRTPWrite(m, p)
+
+	if o := m.onWriteRTP.Load(); o != nil {
+		o.fn(p)
+	}
 
 	writeBuf := m.getWriteBuf()
 

--- a/media/rtp_write_observer.go
+++ b/media/rtp_write_observer.go
@@ -1,0 +1,39 @@
+package media
+
+import "github.com/pion/rtp"
+
+// rtpWriteObserver boxes the callback so it can live in an atomic.Pointer: a
+// func value is not directly storable there, and the box keeps the read on the
+// write path to a single atomic load.
+type rtpWriteObserver struct {
+	fn func(p *rtp.Packet)
+}
+
+// OnWriteRTP registers f to be called with every RTP packet this session sends,
+// from inside WriteRTP. Pass nil to remove it.
+//
+// It is the RTP counterpart of RTPSession.OnReadRTCP / OnWriteRTCP: a place to
+// observe what actually goes on the wire without wrapping the writer.
+//
+// Why it cannot be done from outside: RTPPacketWriter records the last header it
+// wrote in PacketHeader, but writes it under its own lock and exposes no
+// synchronised getter, so reading it after a Write races with anything else
+// sending on the same session — DTMF in particular — and can return the header
+// of a different packet. WriteRTP is the one place every outgoing packet passes
+// through, audio and DTMF alike, and it has the packet in hand.
+//
+// f is called with the packet BEFORE it is marshalled and, on a secure session,
+// before it is encrypted — so an observer sees the media in the clear, which is
+// the point for anything that wants to record or analyse what this endpoint
+// sent. It runs ON the media path: it must be quick and must not block. The
+// packet belongs to the caller and is reused, so anything kept beyond the call
+// has to be copied.
+//
+// Reading the observer costs one atomic load per packet when none is set.
+func (m *MediaSession) OnWriteRTP(f func(p *rtp.Packet)) {
+	if f == nil {
+		m.onWriteRTP.Store(nil)
+		return
+	}
+	m.onWriteRTP.Store(&rtpWriteObserver{fn: f})
+}

--- a/media/rtp_write_observer_test.go
+++ b/media/rtp_write_observer_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2024, Emir Aganovic
+
+package media
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+// The observer must see every packet the session writes, with the header it
+// actually sent — that is the whole reason it exists, since the header cannot be
+// read back afterwards without racing another writer on the same session.
+func TestMediaSessionOnWriteRTP(t *testing.T) {
+	sess := fakeMediaSessionWriter(0, 1234, bytes.NewBuffer([]byte{}))
+
+	type seen struct {
+		seq uint16
+		ts  uint32
+		pt  uint8
+	}
+	var got []seen
+	sess.OnWriteRTP(func(p *rtp.Packet) {
+		got = append(got, seen{p.SequenceNumber, p.Timestamp, p.PayloadType})
+	})
+
+	for i := 0; i < 3; i++ {
+		p := &rtp.Packet{
+			Header:  rtp.Header{Version: 2, SequenceNumber: uint16(100 + i), Timestamp: uint32(160 * i), PayloadType: 8},
+			Payload: []byte("payload"),
+		}
+		require.NoError(t, sess.WriteRTP(p))
+	}
+
+	require.Len(t, got, 3)
+	for i, g := range got {
+		require.Equal(t, uint16(100+i), g.seq)
+		require.Equal(t, uint32(160*i), g.ts)
+		require.Equal(t, uint8(8), g.pt)
+	}
+}
+
+// Passing nil removes the observer, and a session that never had one writes just
+// the same — the write path must not depend on an observer being present.
+func TestMediaSessionOnWriteRTPNil(t *testing.T) {
+	sess := fakeMediaSessionWriter(0, 1234, bytes.NewBuffer([]byte{}))
+
+	calls := 0
+	sess.OnWriteRTP(func(p *rtp.Packet) { calls++ })
+	p := &rtp.Packet{Header: rtp.Header{Version: 2, PayloadType: 8}, Payload: []byte("x")}
+	require.NoError(t, sess.WriteRTP(p))
+	require.Equal(t, 1, calls)
+
+	sess.OnWriteRTP(nil)
+	require.NoError(t, sess.WriteRTP(p))
+	require.Equal(t, 1, calls, "the observer was removed and must not be called again")
+
+	fresh := fakeMediaSessionWriter(0, 1234, bytes.NewBuffer([]byte{}))
+	require.NoError(t, fresh.WriteRTP(p))
+}
+
+// Two sessions observe only their own traffic: the callback is per session, not
+// a package-level hook.
+func TestMediaSessionOnWriteRTPIsPerSession(t *testing.T) {
+	a := fakeMediaSessionWriter(0, 1234, bytes.NewBuffer([]byte{}))
+	b := fakeMediaSessionWriter(0, 1234, bytes.NewBuffer([]byte{}))
+
+	var seenA, seenB int
+	a.OnWriteRTP(func(p *rtp.Packet) { seenA++ })
+	b.OnWriteRTP(func(p *rtp.Packet) { seenB++ })
+
+	p := &rtp.Packet{Header: rtp.Header{Version: 2, PayloadType: 8}, Payload: []byte("x")}
+	require.NoError(t, a.WriteRTP(p))
+	require.NoError(t, a.WriteRTP(p))
+	require.NoError(t, b.WriteRTP(p))
+
+	require.Equal(t, 2, seenA)
+	require.Equal(t, 1, seenB)
+}


### PR DESCRIPTION
## The gap

There is no way to observe an outgoing RTP packet together with the header that
was actually put on the wire.

`RTPPacketWriter` records the last one in `PacketHeader`, but it writes it under
its own lock and exposes no synchronised getter. Reading it after a `Write`
therefore races with anything else sending on the same session — DTMF is the
common case, since `RTPDTMFWriter` shares the stream — and can return the header
of a different packet. Reconstructing the sequence number and timestamp outside
the library is not an option either when the numbers are meant to be measured
rather than estimated.

The inbound direction has no such problem: the reader exposes the header of the
packet you just read, in the same turn.

## The change

`MediaSession.WriteRTP` is the single point every outgoing packet passes
through — audio and DTMF alike — and it already holds the packet. This adds an
observer there:

```go
sess.OnWriteRTP(func(p *rtp.Packet) {
    // p is the packet as sent: real sequence, timestamp, marker, SSRC, PT
})
sess.OnWriteRTP(nil) // remove
```

The callback runs before the packet is marshalled and, on a secure session,
before it is encrypted, so an observer sees the media in the clear. That is what
makes it useful for recording and for analysing what this endpoint actually
sent, as opposed to what it was asked to send.

## Design notes

I tried to make this look like it was already there rather than bolted on:

- **Per session, not package level.** It mirrors the shape of
  `RTPSession.OnReadRTCP` / `OnWriteRTCP`, which is the existing precedent in
  this codebase for "let me see what goes by". Two sessions observe only their
  own traffic.
- **`atomic.Pointer`, following `learnedRTPFrom` in the same struct.** A session
  with no observer pays one atomic load per packet and takes no lock on the
  media path. `MediaSession` has no mutex today and this does not add one.
- **The doc comment says what the caller must not assume**: the packet belongs
  to the caller and is reused, so anything kept beyond the call has to be
  copied; and the callback runs on the media path, so it must be quick and must
  not block.

Three files, 128 lines added, nothing removed or reordered:

```
media/media_session.go             |  7 ++   the field, and the call in WriteRTP
media/rtp_write_observer.go        | 39 ++   the type and the method
media/rtp_write_observer_test.go   | 82 ++   the tests
```

## Testing

`go test ./media/` passes. The three new tests cover:

1. the observer sees each packet with its real sequence, timestamp and payload
   type;
2. `nil` removes it, and a session that never had one writes just the same —
   the write path must not depend on an observer being present;
3. two sessions observe only their own traffic.

## Context

I maintain a browser-based softphone that uses diago as its media layer, and it
needs the outgoing media with its real RTP headers so that a passive analysis
of a call agrees, packet for packet, with what the endpoint sent. I have been
carrying this as a local patch on a vendored copy; upstreaming it means one less
fork to keep in step, and I suspect anyone doing call recording or media quality
analysis on top of diago hits the same wall.

Happy to rename it (`OnRTPWrite`, `SetRTPWriteObserver`, …), to move it onto
`RTPSession` instead of `MediaSession`, or to take the callback as an option at
session construction, if any of those fits your plans better.
